### PR TITLE
Remove unused methods and constants

### DIFF
--- a/lib/constants/design_constants.dart
+++ b/lib/constants/design_constants.dart
@@ -15,5 +15,4 @@ class DesignConstants {
   // Icon sizes
   static const double iconSizeSmall = 16.0;
   static const double iconSizeStandard = 20.0;
-  static const double iconSizeLarge = 24.0;
 }

--- a/lib/services/window_manager.dart
+++ b/lib/services/window_manager.dart
@@ -1,85 +1,12 @@
-import 'dart:convert';
-import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import '../constants/design_constants.dart';
 
 class WindowManager {
-  static const String _windowTitle = 'Tsubusu';
-  static const Size _defaultWindowSize = Size(300, 400);
-  static const Offset _defaultWindowPosition = Offset(100, 100);
-  static const Offset _offsetWindowPosition = Offset(130, 130);
-
   static Future<void> updateWindowTitle(String title) async {
     try {
       const MethodChannel('tsubusu/window_manager').invokeMethod('updateWindowTitle', {'title': title});
     } catch (e) {
       debugPrint('Failed to update window title: $e');
     }
-  }
-
-  /// Creates a new window with the todo app
-  static Future<WindowController?> createNewWindow({Offset? position}) async {
-    try {
-      final window = await DesktopMultiWindow.createWindow(jsonEncode({
-        'type': 'todo_window',
-        'timestamp': DateTime.now().millisecondsSinceEpoch,
-      }));
-
-      final newPosition = position ?? _defaultWindowPosition;
-
-      await window.setFrame(newPosition & _defaultWindowSize);
-      await window.setTitle(_windowTitle);
-      await window.show();
-
-      return window;
-    } catch (e) {
-      debugPrint('Failed to create new window: $e');
-      return null;
-    }
-  }
-
-  /// Shows a window creation menu at the specified position
-  static void showWindowMenu(BuildContext context, Offset position) {
-    showMenu(
-      context: context,
-      position: RelativeRect.fromLTRB(
-        position.dx,
-        position.dy,
-        position.dx + 1,
-        position.dy + 1,
-      ),
-      items: [
-        PopupMenuItem(
-          value: 'new_window',
-          child: Row(
-            children: [
-              Icon(Icons.add, size: DesignConstants.iconSizeSmall),
-              SizedBox(width: DesignConstants.spacingSmall),
-              const Text('New Window'),
-            ],
-          ),
-        ),
-        PopupMenuItem(
-          value: 'new_window_here',
-          child: Row(
-            children: [
-              Icon(Icons.open_in_new, size: DesignConstants.iconSizeSmall),
-              SizedBox(width: DesignConstants.spacingSmall),
-              const Text('New Window Here'),
-            ],
-          ),
-        ),
-      ],
-    ).then((value) {
-      switch (value) {
-        case 'new_window':
-          createNewWindow(position: _offsetWindowPosition);
-          break;
-        case 'new_window_here':
-          createNewWindow();
-          break;
-      }
-    });
   }
 }


### PR DESCRIPTION
Dead code removed:
- WindowManager.createNewWindow() - never called
- WindowManager.showWindowMenu() - never called
- WindowManager._windowTitle - only used in createNewWindow
- WindowManager._defaultWindowSize - only used in createNewWindow
- WindowManager._defaultWindowPosition - only used in createNewWindow
- WindowManager._offsetWindowPosition - only used in showWindowMenu
- DesignConstants.iconSizeLarge - never used

Also removed unused imports:
- dart:convert (from WindowManager)
- desktop_multi_window package (from WindowManager)
- design_constants (from WindowManager)

Impact:
- Reduced WindowManager from 85 lines to 12 lines
- Reduced DesignConstants from 19 lines to 18 lines
- All 116 tests still pass
- No functionality affected

