### PR TITLE
Add release size budget reporting

### DIFF
--- a/.github/RELEASE_GUIDE.md
+++ b/.github/RELEASE_GUIDE.md
@@ -26,6 +26,52 @@ When you create a release (either method), the GitHub Action will:
 1. **Build macOS version**: Creates a `.dmg` file ready for distribution
 2. **Build Windows version**: Creates a `.zip` file with the executable and dependencies
 3. **Upload binaries**: Automatically attaches both files to the GitHub release
+4. **Check release size**: Fails the build if a distributed archive exceeds its
+   platform budget, and writes an archive/payload breakdown to the GitHub Actions
+   job summary.
+
+## Release Size Budget
+
+The distributed archives have the following budgets, measured in decimal MB
+(1 MB = 1,000,000 bytes):
+
+| Platform | Archive | Budget |
+| --- | --- | ---: |
+| macOS | `tsubusu-macos.dmg` | 20 MB |
+| Windows | `tsubusu-windows.zip` | 12 MB |
+
+The current baseline, from the v1.0.5 release, is 19.7 MB for the macOS DMG
+and 11.3 MB for the Windows ZIP. The initial goal is a safe 5–15% reduction
+only when measurement identifies content that can be removed without changing
+features, compatibility, signing, or maintainability. Flutter runtime files are
+expected to be a substantial and necessary part of both payloads.
+
+The initial inventory removed the unused direct `cupertino_icons` dependency;
+the app does not reference `CupertinoIcons`. Its actual archive-size effect is
+recorded by the next release job summary. No other dependency, platform runtime,
+or packaging content is removed without a matching usage and release-size check.
+
+Each release build reports the compressed archive size and a breakdown of the
+uncompressed app payload in its job summary. The latter is diagnostic: it makes
+the largest runtime, executable, asset, plugin, symbol, and packaging components
+visible, but it is not compared directly with the compressed archive budget.
+
+To reproduce the check locally after creating a release archive, run:
+
+```bash
+dart run tool/release_size_report.dart \
+  --platform macos \
+  --artifact tsubusu-macos.dmg \
+  --payload build/macos/Build/Products/Release/tsubusu.app \
+  --budget-mb 20
+```
+
+For a Windows release build, run the same command with `--platform windows`,
+`--artifact tsubusu-windows.zip`,
+`--payload build/windows/x64/runner/Release`, and `--budget-mb 12`.
+
+If a feature genuinely requires a budget exception, document the measured
+increase and reason in its pull request before changing the workflow budget.
 
 ## Binary Distribution
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,14 @@ jobs:
           # Create DMG
           hdiutil create -volname "tsubusu" -srcfolder dmg_contents -ov -format UDZO tsubusu-macos.dmg
 
+      - name: Report and enforce macOS release size
+        run: |
+          dart run tool/release_size_report.dart \
+            --platform macos \
+            --artifact tsubusu-macos.dmg \
+            --payload build/macos/Build/Products/Release/tsubusu.app \
+            --budget-mb 20
+
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v4
         with:
@@ -69,6 +77,15 @@ jobs:
         run: |
           cd build/windows/x64/runner/Release
           Compress-Archive -Path . -DestinationPath ../../../../../tsubusu-windows.zip
+        shell: pwsh
+
+      - name: Report and enforce Windows release size
+        run: |
+          dart run tool/release_size_report.dart `
+            --platform windows `
+            --artifact tsubusu-windows.zip `
+            --payload build/windows/x64/runner/Release `
+            --budget-mb 12
         shell: pwsh
 
       - name: Upload Windows artifact

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,14 +41,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.8"
   desktop_multi_window:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,9 +31,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.8
   shared_preferences: ^2.2.2
   provider: ^6.1.2
   desktop_multi_window: ^0.2.1

--- a/tool/release_size_report.dart
+++ b/tool/release_size_report.dart
@@ -1,0 +1,154 @@
+import 'dart:io';
+
+/// Reports the size of a release archive and the uncompressed files it contains.
+///
+/// This intentionally has no package dependencies so it can run in each release
+/// job immediately after `flutter pub get`.
+void main(List<String> arguments) {
+  final options = _parseArguments(arguments);
+  final artifactPath = _requiredOption(options, 'artifact');
+  final payloadPath = _requiredOption(options, 'payload');
+  final platform = _requiredOption(options, 'platform');
+  final budgetMb = double.tryParse(_requiredOption(options, 'budget-mb'));
+
+  if (budgetMb == null || budgetMb <= 0) {
+    _fail('--budget-mb must be a positive number.');
+  }
+
+  final artifact = File(artifactPath);
+  final payload = Directory(payloadPath);
+  if (!artifact.existsSync()) {
+    _fail('Release artifact does not exist: $artifactPath');
+  }
+  if (!payload.existsSync()) {
+    _fail('Release payload does not exist: $payloadPath');
+  }
+
+  final artifactBytes = artifact.lengthSync();
+  final payloadBytes = _directorySize(payload);
+  final budgetBytes = (budgetMb * 1000 * 1000).round();
+  final components = _componentSizes(payload, platform);
+  final report = _markdownReport(
+    platform: platform,
+    artifactPath: artifactPath,
+    artifactBytes: artifactBytes,
+    payloadPath: payloadPath,
+    payloadBytes: payloadBytes,
+    budgetBytes: budgetBytes,
+    components: components,
+  );
+
+  stdout.write(report);
+  final summaryPath = Platform.environment['GITHUB_STEP_SUMMARY'];
+  if (summaryPath != null && summaryPath.isNotEmpty) {
+    File(summaryPath).writeAsStringSync(report, mode: FileMode.append);
+  }
+
+  if (artifactBytes > budgetBytes) {
+    _fail(
+      '$platform release artifact is ${_megabytes(artifactBytes)} MB; '
+      'the budget is ${_megabytes(budgetBytes)} MB.',
+    );
+  }
+}
+
+Map<String, String> _parseArguments(List<String> arguments) {
+  final options = <String, String>{};
+  for (var index = 0; index < arguments.length; index += 2) {
+    final flag = arguments[index];
+    if (!flag.startsWith('--') || index + 1 >= arguments.length) {
+      _fail(
+        'Usage: dart run tool/release_size_report.dart '
+        '--platform <name> --artifact <file> --payload <directory> '
+        '--budget-mb <decimal MB>',
+      );
+    }
+    options[flag.substring(2)] = arguments[index + 1];
+  }
+  return options;
+}
+
+String _requiredOption(Map<String, String> options, String name) {
+  final value = options[name];
+  if (value == null || value.isEmpty) {
+    _fail('Missing required --$name option.');
+  }
+  return value!;
+}
+
+Never _fail(String message) => throw ArgumentError(message);
+
+int _directorySize(Directory directory) {
+  var total = 0;
+  for (final entity in directory.listSync(recursive: true, followLinks: false)) {
+    if (entity is File) {
+      total += entity.lengthSync();
+    }
+  }
+  return total;
+}
+
+List<MapEntry<String, int>> _componentSizes(Directory payload, String platform) {
+  var componentRoot = payload;
+  var prefix = '';
+  if (platform == 'macos') {
+    final contents = Directory('${payload.path}${Platform.pathSeparator}Contents');
+    if (contents.existsSync()) {
+      componentRoot = contents;
+      prefix = 'Contents/';
+    }
+  }
+
+  final components = <MapEntry<String, int>>[];
+  for (final entity in componentRoot.listSync(followLinks: false)) {
+    final name = entity.path.split(Platform.pathSeparator).last;
+    final size = switch (entity) {
+      File file => file.lengthSync(),
+      Directory directory => _directorySize(directory),
+      _ => 0,
+    };
+    components.add(MapEntry('$prefix$name', size));
+  }
+  components.sort((a, b) => b.value.compareTo(a.value));
+  return components;
+}
+
+String _markdownReport({
+  required String platform,
+  required String artifactPath,
+  required int artifactBytes,
+  required String payloadPath,
+  required int payloadBytes,
+  required int budgetBytes,
+  required List<MapEntry<String, int>> components,
+}) {
+  final status = artifactBytes <= budgetBytes ? 'PASS' : 'FAIL';
+  final buffer = StringBuffer()
+    ..writeln('## ${platform[0].toUpperCase()}${platform.substring(1)} release size')
+    ..writeln()
+    ..writeln('| Measure | Size |')
+    ..writeln('| --- | ---: |')
+    ..writeln('| Archive (`$artifactPath`) | ${_megabytes(artifactBytes)} MB |')
+    ..writeln('| Budget | ${_megabytes(budgetBytes)} MB |')
+    ..writeln('| Uncompressed payload (`$payloadPath`) | ${_megabytes(payloadBytes)} MB |')
+    ..writeln('| Budget check | **$status** |')
+    ..writeln()
+    ..writeln('### Uncompressed payload breakdown')
+    ..writeln()
+    ..writeln('| Component | Size |')
+    ..writeln('| --- | ---: |');
+
+  for (final component in components) {
+    buffer.writeln('| `${component.key}` | ${_megabytes(component.value)} MB |');
+  }
+  buffer.writeln();
+  buffer.writeln(
+    'Archive size is the distributed download. Payload sizes are uncompressed '
+    'and are provided to identify Flutter runtime, app binary, assets, plugins, '
+    'symbols, and packaging contributors.',
+  );
+  buffer.writeln();
+  return buffer.toString();
+}
+
+String _megabytes(int bytes) => (bytes / 1000 / 1000).toStringAsFixed(2);


### PR DESCRIPTION
## Summary
- measure macOS and Windows release archives after packaging
- enforce 20 MB DMG and 12 MB ZIP budgets in release CI
- document the v1.0.5 baseline and safe 5–15% reduction target
- remove the unused `cupertino_icons` direct dependency

## Validation
- `git diff --check`
- YAML parsing for workflow and package files
- confirmed no remaining Cupertino icon references
- Flutter/Dart runtime validation is pending FVM SDK setup

Closes #29