### PR TITLE
Document safe generated artifact cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ migrate_working_dir/
 .pub-cache/
 .pub/
 /build/
+/coverage/
 
 # Symbolication related
 app.*.symbols

--- a/README.md
+++ b/README.md
@@ -24,6 +24,38 @@ To run the app:
 flutter run -d macos
 ```
 
+### Generated artifacts and cleanup
+
+Build output and tool state are generated locally and must not be committed.
+Use the cleanup tool instead of a broad command such as `git clean`, which can
+remove unrelated ignored files.
+
+For the usual clean build, remove only Flutter/Dart build state:
+
+```bash
+dart run tool/clean_generated.dart --normal
+flutter pub get
+flutter run -d macos
+```
+
+For a fully reproducible desktop environment, also remove generated CocoaPods
+and platform ephemeral files before regenerating them from the committed
+lockfiles on the next platform build:
+
+```bash
+dart run tool/clean_generated.dart --full
+flutter pub get
+flutter run -d macos
+```
+
+Add `--dry-run` to either command to review the exact paths first. Normal
+cleanup removes `build/`, `coverage/`, `.dart_tool/`, and Flutter's generated
+plugin state. Full cleanup additionally removes only `macos/Pods/`,
+`macos/Flutter/ephemeral/`, and `windows/flutter/ephemeral/`. The commands do
+not target source files, `pubspec.lock`, `macos/Podfile.lock`, Xcode project
+configuration, entitlements/signing configuration, credentials, or app user
+data.
+
 ## Requirements
 
 - Flutter SDK (3.29.3 or later)

--- a/tool/clean_generated.dart
+++ b/tool/clean_generated.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+
+const _normalTargets = <String>[
+  'build',
+  'coverage',
+  '.dart_tool',
+  '.flutter-plugins',
+  '.flutter-plugins-dependencies',
+];
+
+const _fullOnlyTargets = <String>[
+  'macos/Flutter/ephemeral',
+  'macos/Pods',
+  'windows/flutter/ephemeral',
+];
+
+void main(List<String> arguments) {
+  final flags = arguments.toSet();
+  const validFlags = {'--normal', '--full', '--dry-run', '--help'};
+  if (flags.length != arguments.length || !flags.every(validFlags.contains)) {
+    _usage(exitCode: 64);
+  }
+
+  if (flags.contains('--help') ||
+      (!flags.contains('--normal') && !flags.contains('--full'))) {
+    _usage(exitCode: flags.contains('--help') ? 0 : 64);
+  }
+
+  if (flags.contains('--normal') && flags.contains('--full')) {
+    stderr.writeln('Choose either --normal or --full.');
+    exitCode = 64;
+    return;
+  }
+
+  final repositoryRoot = File.fromUri(Platform.script).parent.parent;
+  final targets = [
+    ..._normalTargets,
+    if (flags.contains('--full')) ..._fullOnlyTargets,
+  ];
+  final dryRun = flags.contains('--dry-run');
+
+  for (final relativePath in targets) {
+    final targetPath = '${repositoryRoot.path}/$relativePath';
+    final type = FileSystemEntity.typeSync(targetPath, followLinks: false);
+    if (type == FileSystemEntityType.notFound) {
+      stdout.writeln('Already absent: $relativePath');
+      continue;
+    }
+
+    if (type == FileSystemEntityType.link) {
+      stderr.writeln('Refusing to remove symlink: $relativePath');
+      exitCode = 1;
+      continue;
+    }
+
+    if (dryRun) {
+      stdout.writeln('Would remove: $relativePath');
+      continue;
+    }
+
+    if (type == FileSystemEntityType.directory) {
+      Directory(targetPath).deleteSync(recursive: true);
+    } else if (type == FileSystemEntityType.file) {
+      File(targetPath).deleteSync();
+    } else {
+      stderr.writeln('Refusing unexpected filesystem entry: $relativePath');
+      exitCode = 1;
+      continue;
+    }
+    stdout.writeln('Removed: $relativePath');
+  }
+}
+
+void _usage({required int exitCode}) {
+  final output = exitCode == 0 ? stdout : stderr;
+  output.writeln('''Usage: dart run tool/clean_generated.dart <mode> [--dry-run]
+
+Modes:
+  --normal  Remove Flutter build and Dart/Pub generated state.
+  --full    Also remove regenerated macOS CocoaPods and platform ephemeral state.
+
+The command only removes the explicitly listed generated paths. It never
+removes source, lockfiles, signing configuration, credentials, or user data.''');
+  if (exitCode != 0) {
+    exit(exitCode);
+  }
+}


### PR DESCRIPTION
## Summary
- add an explicit generated-artifact cleanup tool with normal, full, and dry-run modes
- protect source, lockfiles, signing configuration, credentials, and user data from cleanup
- document reproducible cleanup and ignore coverage output

## Validation
- `git diff --check`
- verified intended generated paths with `git check-ignore --no-index`
- Flutter/Dart runtime validation is pending FVM SDK setup

Closes #30