### PR TITLE
Fix release size report lint

### DIFF
--- a/tool/release_size_report.dart
+++ b/tool/release_size_report.dart
@@ -73,7 +73,7 @@ String _requiredOption(Map<String, String> options, String name) {
   if (value == null || value.isEmpty) {
     _fail('Missing required --$name option.');
   }
-  return value!;
+  return value;
 }
 
 Never _fail(String message) => throw ArgumentError(message);


### PR DESCRIPTION
## Summary
- remove the redundant non-null assertion in the release-size report argument helper

## Validation
- `fvm spawn 3.29.3 analyze`

Closes #39