### PR TITLE
Add subtask support

### DIFF
--- a/lib/models/todo.dart
+++ b/lib/models/todo.dart
@@ -2,19 +2,27 @@ class Todo {
   String text;
   bool isCompleted;
   final String id;
+  final String? parentId;
 
-  Todo({required this.text, required this.isCompleted, String? id})
-      : id = id ?? DateTime.now().millisecondsSinceEpoch.toString();
+  Todo({
+    required this.text,
+    required this.isCompleted,
+    String? id,
+    this.parentId,
+  }) : id = id ?? DateTime.now().microsecondsSinceEpoch.toString();
 
   Todo copyWith({
     String? text,
     bool? isCompleted,
     String? id,
+    String? parentId,
+    bool clearParentId = false,
   }) {
     return Todo(
       text: text ?? this.text,
       isCompleted: isCompleted ?? this.isCompleted,
       id: id ?? this.id,
+      parentId: clearParentId ? null : parentId ?? this.parentId,
     );
   }
 
@@ -23,6 +31,7 @@ class Todo {
       'id': id,
       'text': text,
       'isCompleted': isCompleted,
+      'parentId': parentId,
     };
   }
 
@@ -31,6 +40,7 @@ class Todo {
       id: json['id'],
       text: json['text'],
       isCompleted: json['isCompleted'],
+      parentId: json['parentId'] as String?,
     );
   }
 }

--- a/lib/services/todo_list_service.dart
+++ b/lib/services/todo_list_service.dart
@@ -19,6 +19,16 @@ class TodoListService extends ChangeNotifier {
 
   List<Todo> get todos => List.unmodifiable(_todos);
 
+  Todo? todoById(String id) {
+    for (final todo in _todos) {
+      if (todo.id == id) return todo;
+    }
+    return null;
+  }
+
+  List<Todo> childrenOf(String parentId) =>
+      List.unmodifiable(_todos.where((todo) => todo.parentId == parentId));
+
   Future<void> _loadTodos() async {
     try {
       await _repository.migrateLegacyWindowTodos();
@@ -48,6 +58,37 @@ class TodoListService extends ChangeNotifier {
     await _saveTodos();
   }
 
+  Future<void> addSubtask(String parentId, String text) async {
+    if (text.trim().isEmpty || todoById(parentId) == null) return;
+
+    final parent = todoById(parentId)!;
+    final child = Todo(
+      text: text.trim(),
+      isCompleted: false,
+      parentId: parentId,
+    );
+    final siblingIndexes = [
+      for (var i = 0; i < _todos.length; i++)
+        if (_todos[i].parentId == parentId) i,
+    ];
+    final insertAt =
+        siblingIndexes.isEmpty
+            ? _todos.indexOf(parent) + 1
+            : siblingIndexes.last + 1;
+    _todos.insert(insertAt, child);
+    parent.isCompleted = false;
+    notifyListeners();
+    await _saveTodos();
+  }
+
+  Future<void> updateTodoText(String id, String text) async {
+    final todo = todoById(id);
+    if (todo == null || text.trim().isEmpty) return;
+    todo.text = text.trim();
+    notifyListeners();
+    await _saveTodos();
+  }
+
   Future<void> toggleTodo(int index) async {
     if (index >= 0 && index < _todos.length) {
       _todos[index].isCompleted = !_todos[index].isCompleted;
@@ -56,12 +97,77 @@ class TodoListService extends ChangeNotifier {
     }
   }
 
+  Future<void> toggleTodoById(String id) async {
+    final todo = todoById(id);
+    if (todo == null) return;
+
+    final nextValue = !todo.isCompleted;
+    final descendants =
+        _todos.where((candidate) => candidate.parentId == id).toList();
+    todo.isCompleted = nextValue;
+    if (descendants.isNotEmpty) {
+      for (final child in descendants) {
+        child.isCompleted = nextValue;
+      }
+    } else if (todo.parentId != null) {
+      _syncParentCompletion(todo.parentId!);
+    }
+    notifyListeners();
+    await _saveTodos();
+  }
+
+  void _syncParentCompletion(String parentId) {
+    final parent = todoById(parentId);
+    final children = childrenOf(parentId);
+    if (parent == null || children.isEmpty) return;
+    parent.isCompleted = children.every((child) => child.isCompleted);
+  }
+
   Future<void> deleteTodo(int index) async {
     if (index >= 0 && index < _todos.length) {
       _todos.removeAt(index);
       notifyListeners();
       await _saveTodos();
     }
+  }
+
+  Future<void> deleteTodoById(String id) async {
+    if (todoById(id) == null) return;
+    final idsToDelete = <String>{id};
+    for (final todo in _todos) {
+      if (todo.parentId == id) idsToDelete.add(todo.id);
+    }
+    _todos.removeWhere((todo) => idsToDelete.contains(todo.id));
+    notifyListeners();
+    await _saveTodos();
+  }
+
+  Future<void> reorderSiblings(
+    String? parentId,
+    int oldIndex,
+    int newIndex,
+  ) async {
+    final siblings = _todos.where((todo) => todo.parentId == parentId).toList();
+    if (oldIndex < 0 ||
+        oldIndex >= siblings.length ||
+        newIndex < 0 ||
+        newIndex > siblings.length) {
+      return;
+    }
+    if (oldIndex < newIndex) newIndex -= 1;
+    if (oldIndex == newIndex) return;
+
+    final moved = siblings.removeAt(oldIndex);
+    siblings.insert(newIndex, moved);
+    final siblingIds = siblings.map((todo) => todo.id).toSet();
+    var siblingCursor = 0;
+    for (var i = 0; i < _todos.length; i++) {
+      if (siblingIds.contains(_todos[i].id)) {
+        _todos[i] = siblings[siblingCursor++];
+      }
+    }
+    notifyListeners();
+    await _saveTodos();
   }
 
   Future<void> reorderTodo(int oldIndex, int newIndex) async {

--- a/lib/widgets/molecules/todo_item.dart
+++ b/lib/widgets/molecules/todo_item.dart
@@ -1,83 +1,223 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
 import '../../constants/design_constants.dart';
 import '../../models/todo.dart';
 import '../../providers/theme_provider.dart';
-import '../atoms/icon_button_atom.dart';
-import '../atoms/custom_text.dart';
 import '../atoms/animated_checkbox.dart';
+import '../atoms/custom_text.dart';
+import '../atoms/icon_button_atom.dart';
 
-class TodoItem extends StatelessWidget {
+class TodoItem extends StatefulWidget {
   final Todo todo;
   final VoidCallback onToggle;
   final VoidCallback onDelete;
-  final int? reorderIndex; // For drag handle
-  final bool isCompleted; // Whether this item is in completed section
+  final VoidCallback? onAddSubtask;
+  final ValueChanged<String>? onEdit;
+  final VoidCallback? onToggleExpanded;
+  final bool hasChildren;
+  final bool isExpanded;
+  final int? reorderIndex;
+  final bool isCompleted;
+  final bool isSubtask;
 
   const TodoItem({
     super.key,
     required this.todo,
     required this.onToggle,
     required this.onDelete,
+    this.onAddSubtask,
+    this.onEdit,
+    this.onToggleExpanded,
+    this.hasChildren = false,
+    this.isExpanded = true,
     this.reorderIndex,
     this.isCompleted = false,
+    this.isSubtask = false,
   });
+
+  @override
+  State<TodoItem> createState() => _TodoItemState();
+}
+
+class _TodoItemState extends State<TodoItem> {
+  final _editController = TextEditingController();
+  final _editFocusNode = FocusNode();
+  bool _isHovered = false;
+  bool _isEditing = false;
+
+  @override
+  void dispose() {
+    _editController.dispose();
+    _editFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _startEditing() {
+    if (widget.onEdit == null) return;
+    setState(() {
+      _isEditing = true;
+      _editController.text = widget.todo.text;
+      _editController.selection = TextSelection.collapsed(
+        offset: _editController.text.length,
+      );
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _editFocusNode.requestFocus();
+    });
+  }
+
+  void _finishEditing({bool cancel = false}) {
+    if (!_isEditing) return;
+    final text = _editController.text.trim();
+    setState(() => _isEditing = false);
+    if (!cancel && text.isNotEmpty && text != widget.todo.text) {
+      widget.onEdit?.call(text);
+    }
+  }
+
+  void _showActions(BuildContext context, [Offset? globalPosition]) {
+    final box = context.findRenderObject() as RenderBox;
+    final position = globalPosition ?? box.localToGlobal(Offset.zero);
+    showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy + box.size.height,
+        position.dx + 1,
+        position.dy,
+      ),
+      items: [
+        if (widget.onAddSubtask != null)
+          const PopupMenuItem(value: 'add', child: Text('サブタスクを追加')),
+        if (widget.onEdit != null)
+          const PopupMenuItem(value: 'edit', child: Text('名前を変更')),
+        const PopupMenuItem(value: 'delete', child: Text('削除')),
+      ],
+    ).then((value) {
+      if (!mounted) return;
+      switch (value) {
+        case 'add':
+          widget.onAddSubtask?.call();
+        case 'edit':
+          _startEditing();
+        case 'delete':
+          widget.onDelete();
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     final themeProvider = Provider.of<ThemeProvider>(context);
-    
-    return Container(
-      margin: EdgeInsets.only(bottom: DesignConstants.spacingSmall),
-      decoration: BoxDecoration(
-        color: themeProvider.cardColor,
-        borderRadius: BorderRadius.circular(DesignConstants.borderRadiusStandard),
-        boxShadow: [
-          BoxShadow(
-            color: themeProvider.shadowColor,
-            blurRadius: 2,
-            offset: const Offset(0, 1),
-          ),
-        ],
-      ),
-      child: ListTile(
-        leading: AnimatedCheckbox(
-          value: todo.isCompleted,
-          onChanged: (_) => onToggle(),
-          activeColor: themeProvider.primaryColor,
-          isStatic: isCompleted, // Use static mode for completed section
-        ),
-        title: CustomText(
-          todo.text,
-          style: TextStyle(
-            decoration: todo.isCompleted ? TextDecoration.lineThrough : null,
-            color: todo.isCompleted ? themeProvider.completedTextColor : themeProvider.textColor,
-          ),
-        ),
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            IconButtonAtom(
-              icon: Icons.delete_outline,
-              onPressed: onDelete,
-              iconColor: themeProvider.completedTextColor,
-              size: DesignConstants.iconSizeStandard,
+    final textStyle = TextStyle(
+      decoration: widget.todo.isCompleted ? TextDecoration.lineThrough : null,
+      color:
+          widget.todo.isCompleted
+              ? themeProvider.completedTextColor
+              : themeProvider.textColor,
+    );
+
+    return MouseRegion(
+      onEnter: (_) => setState(() => _isHovered = true),
+      onExit: (_) => setState(() => _isHovered = false),
+      child: GestureDetector(
+        onSecondaryTapUp:
+            (details) => _showActions(context, details.globalPosition),
+        onLongPress: () => _showActions(context),
+        onDoubleTap: _startEditing,
+        child: Container(
+          margin: EdgeInsets.only(bottom: DesignConstants.spacingSmall),
+          decoration: BoxDecoration(
+            color: themeProvider.cardColor,
+            borderRadius: BorderRadius.circular(
+              DesignConstants.borderRadiusStandard,
             ),
-            // Hamburger menu for drag and drop (only for open tasks)
-            if (!todo.isCompleted && reorderIndex != null) ...[
-              SizedBox(width: DesignConstants.spacingSmall),
-              ReorderableDragStartListener(
-                index: reorderIndex!,
-                child: Icon(
-                  Icons.drag_handle,
-                  color: themeProvider.completedTextColor,
-                  size: DesignConstants.iconSizeStandard,
-                ),
+            boxShadow: [
+              BoxShadow(
+                color: themeProvider.shadowColor,
+                blurRadius: 2,
+                offset: const Offset(0, 1),
               ),
             ],
-          ],
+          ),
+          child: ListTile(
+            contentPadding: EdgeInsets.only(
+              left:
+                  widget.isSubtask
+                      ? DesignConstants.spacingMedium * 2
+                      : DesignConstants.spacingSmall,
+              right: DesignConstants.spacingSmall,
+            ),
+            leading: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (widget.hasChildren)
+                  IconButton(
+                    icon: Icon(
+                      widget.isExpanded
+                          ? Icons.keyboard_arrow_down
+                          : Icons.chevron_right,
+                    ),
+                    onPressed: widget.onToggleExpanded,
+                    tooltip: widget.isExpanded ? '折りたたむ' : '展開する',
+                  )
+                else if (!widget.isSubtask)
+                  const SizedBox(width: 48),
+                AnimatedCheckbox(
+                  value: widget.todo.isCompleted,
+                  onChanged: (_) => widget.onToggle(),
+                  activeColor: themeProvider.primaryColor,
+                  isStatic: widget.isCompleted,
+                ),
+              ],
+            ),
+            title:
+                _isEditing
+                    ? TextField(
+                      controller: _editController,
+                      focusNode: _editFocusNode,
+                      autofocus: true,
+                      onSubmitted: (_) => _finishEditing(),
+                      onEditingComplete: _finishEditing,
+                      decoration: const InputDecoration(
+                        isDense: true,
+                        border: InputBorder.none,
+                      ),
+                    )
+                    : CustomText(widget.todo.text, style: textStyle),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (_isHovered && !_isEditing)
+                  IconButton(
+                    icon: const Icon(Icons.more_horiz),
+                    onPressed: () => _showActions(context),
+                    tooltip: 'その他の操作',
+                  ),
+                IconButtonAtom(
+                  icon: Icons.delete_outline,
+                  onPressed: widget.onDelete,
+                  iconColor: themeProvider.completedTextColor,
+                  size: DesignConstants.iconSizeStandard,
+                ),
+                if (!widget.todo.isCompleted &&
+                    widget.reorderIndex != null) ...[
+                  SizedBox(width: DesignConstants.spacingSmall),
+                  ReorderableDragStartListener(
+                    index: widget.reorderIndex!,
+                    child: Icon(
+                      Icons.drag_handle,
+                      color: themeProvider.completedTextColor,
+                      size: DesignConstants.iconSizeStandard,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+            onTap: _isEditing ? null : widget.onToggle,
+          ),
         ),
-        onTap: () => onToggle(), // Make entire card clickable
       ),
     );
   }

--- a/lib/widgets/organisms/todo_list.dart
+++ b/lib/widgets/organisms/todo_list.dart
@@ -1,23 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
 import '../../constants/design_constants.dart';
 import '../../models/todo.dart';
 import '../../providers/theme_provider.dart';
-import '../../utils/todo_index_helper.dart';
 import '../molecules/todo_item.dart';
 
 class TodoList extends StatefulWidget {
   final List<Todo> todos;
-  final Function(int) onToggleTodo;
-  final Function(int) onDeleteTodo;
-  final Function(int, int)? onReorderTodo;
+  final ValueChanged<String> onToggleTodo;
+  final ValueChanged<String> onDeleteTodo;
+  final void Function(String?, int, int)? onReorderSiblings;
+  final void Function(String, String) onAddSubtask;
+  final void Function(String, String) onEditTodo;
 
   const TodoList({
     super.key,
     required this.todos,
     required this.onToggleTodo,
     required this.onDeleteTodo,
-    this.onReorderTodo,
+    required this.onAddSubtask,
+    required this.onEditTodo,
+    this.onReorderSiblings,
   });
 
   @override
@@ -25,73 +29,63 @@ class TodoList extends StatefulWidget {
 }
 
 class _TodoListState extends State<TodoList> {
-  double _completedSectionHeight = 200.0; // Default height
+  final _collapsedIds = <String>{};
+  String? _addingForId;
+  double _completedSectionHeight = 200.0;
   final double _minCompletedHeight = 80.0;
   final double _maxCompletedHeight = 400.0;
+
+  List<Todo> _childrenOf(String parentId) =>
+      widget.todos.where((todo) => todo.parentId == parentId).toList();
+
+  void _toggleExpanded(String id) {
+    setState(() {
+      if (!_collapsedIds.add(id)) _collapsedIds.remove(id);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     final themeProvider = Provider.of<ThemeProvider>(context);
-    final openTasks = widget.todos.where((todo) => !todo.isCompleted).toList();
-    final completedTasks = widget.todos.where((todo) => todo.isCompleted).toList();
-    final availableHeight = MediaQuery.sizeOf(context).height - MediaQuery.viewInsetsOf(context).bottom;
-    final maxCompletedHeight = (availableHeight * 0.45).clamp(_minCompletedHeight, _maxCompletedHeight);
-    
+    final roots = widget.todos.where((todo) => todo.parentId == null).toList();
+    final openRoots = roots.where((todo) => !todo.isCompleted).toList();
+    final completedRoots = roots.where((todo) => todo.isCompleted).toList();
+    final availableHeight =
+        MediaQuery.sizeOf(context).height -
+        MediaQuery.viewInsetsOf(context).bottom;
+    final maxCompletedHeight = (availableHeight * 0.45).clamp(
+      _minCompletedHeight,
+      _maxCompletedHeight,
+    );
+
     return Expanded(
       child: Column(
         children: [
-          // Open tasks section with drag and drop
           Expanded(
             child: ReorderableListView.builder(
               padding: const EdgeInsets.all(8),
-              itemCount: openTasks.length,
-              buildDefaultDragHandles: false, // Use custom drag handles
-              onReorder: (oldIndex, newIndex) {
-                if (widget.onReorderTodo != null) {
-                  // Convert open task indices to original todo list indices
-                  final indices = TodoIndexHelper.calculateReorderIndices(
-                    widget.todos,
-                    openTasks,
-                    oldIndex,
-                    newIndex,
-                  );
-
-                  widget.onReorderTodo!(indices.originalOldIndex, indices.originalNewIndex);
-                }
-              },
-              itemBuilder: (context, index) {
-                final todo = openTasks[index];
-                final originalIndex = TodoIndexHelper.convertToOriginalIndex(
-                  widget.todos,
-                  openTasks,
-                  index,
-                );
-
-                return TodoItem(
-                  key: ValueKey(todo.id),
-                  todo: todo,
-                  reorderIndex: index,
-                  onToggle: () => widget.onToggleTodo(originalIndex),
-                  onDelete: () => widget.onDeleteTodo(originalIndex),
-                );
-              },
+              buildDefaultDragHandles: false,
+              itemCount: openRoots.length,
+              onReorder:
+                  (oldIndex, newIndex) =>
+                      widget.onReorderSiblings?.call(null, oldIndex, newIndex),
+              itemBuilder:
+                  (context, index) =>
+                      _buildGroup(context, openRoots[index], index),
             ),
           ),
-          
-          // Completed tasks section - at the bottom with resizable divider
-          if (completedTasks.isNotEmpty)
+          if (completedRoots.isNotEmpty)
             Column(
               children: [
-                // Resizable divider
                 MouseRegion(
                   cursor: SystemMouseCursors.resizeUpDown,
                   child: GestureDetector(
-                    onPanUpdate: (details) {
-                      setState(() {
-                        _completedSectionHeight = (_completedSectionHeight - details.delta.dy)
-                            .clamp(_minCompletedHeight, maxCompletedHeight);
-                      });
-                    },
+                    onPanUpdate:
+                        (details) => setState(() {
+                          _completedSectionHeight = (_completedSectionHeight -
+                                  details.delta.dy)
+                              .clamp(_minCompletedHeight, maxCompletedHeight);
+                        }),
                     child: Container(
                       height: 8,
                       color: themeProvider.borderColor,
@@ -100,7 +94,9 @@ class _TodoListState extends State<TodoList> {
                           height: 4,
                           width: 40,
                           decoration: BoxDecoration(
-                            color: themeProvider.completedTextColor.withValues(alpha: DesignConstants.opacityMedium),
+                            color: themeProvider.completedTextColor.withValues(
+                              alpha: DesignConstants.opacityMedium,
+                            ),
                             borderRadius: BorderRadius.circular(2),
                           ),
                         ),
@@ -108,13 +104,15 @@ class _TodoListState extends State<TodoList> {
                     ),
                   ),
                 ),
-                // Completed tasks container
                 Container(
-                  height: _completedSectionHeight.clamp(_minCompletedHeight, maxCompletedHeight),
+                  height: _completedSectionHeight.clamp(
+                    _minCompletedHeight,
+                    maxCompletedHeight,
+                  ),
                   decoration: BoxDecoration(
                     color: themeProvider.completedSectionColor,
                     border: Border(
-                      top: BorderSide(color: themeProvider.borderColor, width: 1),
+                      top: BorderSide(color: themeProvider.borderColor),
                     ),
                   ),
                   child: Column(
@@ -122,7 +120,7 @@ class _TodoListState extends State<TodoList> {
                       Padding(
                         padding: const EdgeInsets.symmetric(vertical: 8),
                         child: Text(
-                          'Completed (${completedTasks.length})',
+                          'Completed (${completedRoots.length})',
                           style: TextStyle(
                             color: themeProvider.completedTextColor,
                             fontSize: 12,
@@ -133,22 +131,14 @@ class _TodoListState extends State<TodoList> {
                       Expanded(
                         child: ListView.builder(
                           padding: const EdgeInsets.symmetric(horizontal: 8),
-                          itemCount: completedTasks.length,
-                          itemBuilder: (context, index) {
-                            final todo = completedTasks[index];
-                            final originalIndex = TodoIndexHelper.convertToOriginalIndex(
-                              widget.todos,
-                              completedTasks,
-                              index,
-                            );
-
-                            return TodoItem(
-                              todo: todo,
-                              onToggle: () => widget.onToggleTodo(originalIndex),
-                              onDelete: () => widget.onDeleteTodo(originalIndex),
-                              isCompleted: true, // Mark as completed section
-                            );
-                          },
+                          itemCount: completedRoots.length,
+                          itemBuilder:
+                              (context, index) => _buildGroup(
+                                context,
+                                completedRoots[index],
+                                null,
+                                completed: true,
+                              ),
                         ),
                       ),
                     ],
@@ -160,4 +150,115 @@ class _TodoListState extends State<TodoList> {
       ),
     );
   }
-} 
+
+  Widget _buildGroup(
+    BuildContext context,
+    Todo parent,
+    int? rootReorderIndex, {
+    bool completed = false,
+  }) {
+    final children = _childrenOf(parent.id);
+    final isExpanded = !_collapsedIds.contains(parent.id);
+    final completedChildren = children.where((todo) => todo.isCompleted).length;
+    return Container(
+      key: ValueKey(parent.id),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          TodoItem(
+            todo: parent,
+            onToggle: () => widget.onToggleTodo(parent.id),
+            onDelete: () => widget.onDeleteTodo(parent.id),
+            onAddSubtask: () => setState(() => _addingForId = parent.id),
+            onEdit: (text) => widget.onEditTodo(parent.id, text),
+            hasChildren: children.isNotEmpty,
+            isExpanded: isExpanded,
+            onToggleExpanded: () => _toggleExpanded(parent.id),
+            reorderIndex: completed ? null : rootReorderIndex,
+            isCompleted: completed,
+          ),
+          if (children.isNotEmpty && isExpanded)
+            ReorderableListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              buildDefaultDragHandles: false,
+              itemCount: children.length,
+              onReorder:
+                  (oldIndex, newIndex) => widget.onReorderSiblings?.call(
+                    parent.id,
+                    oldIndex,
+                    newIndex,
+                  ),
+              itemBuilder: (context, index) {
+                final child = children[index];
+                return TodoItem(
+                  key: ValueKey(child.id),
+                  todo: child,
+                  isSubtask: true,
+                  onToggle: () => widget.onToggleTodo(child.id),
+                  onDelete: () => widget.onDeleteTodo(child.id),
+                  onEdit: (text) => widget.onEditTodo(child.id, text),
+                  reorderIndex: completed ? null : index,
+                  isCompleted: completed,
+                );
+              },
+            ),
+          if (_addingForId == parent.id)
+            Padding(
+              padding: const EdgeInsets.only(left: 56, right: 8, bottom: 8),
+              child: _SubtaskInput(
+                onSubmit: (text) {
+                  setState(() => _addingForId = null);
+                  if (text.trim().isNotEmpty) {
+                    widget.onAddSubtask(parent.id, text);
+                  }
+                },
+                onCancel: () => setState(() => _addingForId = null),
+              ),
+            ),
+          if (children.isNotEmpty && !completed)
+            Padding(
+              padding: const EdgeInsets.only(left: 56, bottom: 6),
+              child: Text(
+                '$completedChildren/${children.length}',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: Theme.of(context).colorScheme.outline,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SubtaskInput extends StatefulWidget {
+  final ValueChanged<String> onSubmit;
+  final VoidCallback onCancel;
+
+  const _SubtaskInput({required this.onSubmit, required this.onCancel});
+
+  @override
+  State<_SubtaskInput> createState() => _SubtaskInputState();
+}
+
+class _SubtaskInputState extends State<_SubtaskInput> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => TextField(
+    controller: _controller,
+    autofocus: true,
+    decoration: const InputDecoration(hintText: 'サブタスクを追加…', isDense: true),
+    onSubmitted: widget.onSubmit,
+    onEditingComplete: () => widget.onSubmit(_controller.text),
+    onTapOutside: (_) => widget.onCancel(),
+  );
+}

--- a/lib/widgets/pages/todo_page.dart
+++ b/lib/widgets/pages/todo_page.dart
@@ -82,16 +82,24 @@ class _TodoPageState extends State<TodoPage> {
     _focusNode.requestFocus();
   }
 
-  void _deleteTodo(int index) {
-    _todoService?.deleteTodo(index);
+  void _deleteTodo(String id) {
+    _todoService?.deleteTodoById(id);
   }
 
-  void _reorderTodo(int oldIndex, int newIndex) {
-    _todoService?.reorderTodo(oldIndex, newIndex);
+  void _reorderSiblings(String? parentId, int oldIndex, int newIndex) {
+    _todoService?.reorderSiblings(parentId, oldIndex, newIndex);
   }
 
-  void _toggleTodoFromIndex(int index) {
-    _todoService?.toggleTodo(index);
+  void _toggleTodo(String id) {
+    _todoService?.toggleTodoById(id);
+  }
+
+  void _addSubtask(String parentId, String text) {
+    _todoService?.addSubtask(parentId, text);
+  }
+
+  void _editTodo(String id, String text) {
+    _todoService?.updateTodoText(id, text);
   }
 
   void _onTitleChanged(String newTitle) {
@@ -133,9 +141,11 @@ class _TodoPageState extends State<TodoPage> {
               builder: (context, child) {
                 return TodoList(
                   todos: _todoService!.todos,
-                  onToggleTodo: _toggleTodoFromIndex,
+                  onToggleTodo: _toggleTodo,
                   onDeleteTodo: _deleteTodo,
-                  onReorderTodo: _reorderTodo,
+                  onReorderSiblings: _reorderSiblings,
+                  onAddSubtask: _addSubtask,
+                  onEditTodo: _editTodo,
                 );
               },
             ),

--- a/test/todo_list_service_test.dart
+++ b/test/todo_list_service_test.dart
@@ -52,6 +52,57 @@ void main() {
       expect(todoListService.todos.first.isCompleted, isTrue);
     });
 
+    test('supports subtasks and parent completion rules', () async {
+      await todoListService.addTodo('Project');
+      final parent = todoListService.todos.single;
+
+      await todoListService.addSubtask(parent.id, 'Design');
+      await todoListService.addSubtask(parent.id, 'Build');
+      final children = todoListService.childrenOf(parent.id);
+
+      expect(children, hasLength(2));
+      expect(children.every((todo) => todo.parentId == parent.id), isTrue);
+
+      await todoListService.toggleTodoById(children.first.id);
+      expect(todoListService.todoById(parent.id)!.isCompleted, isFalse);
+
+      await todoListService.toggleTodoById(children.last.id);
+      expect(todoListService.todoById(parent.id)!.isCompleted, isTrue);
+
+      await todoListService.toggleTodoById(parent.id);
+      expect(
+        todoListService
+            .childrenOf(parent.id)
+            .every((todo) => !todo.isCompleted),
+        isTrue,
+      );
+      expect(todoListService.todoById(parent.id)!.isCompleted, isFalse);
+    });
+
+    test('deleting a parent deletes its subtasks', () async {
+      await todoListService.addTodo('Project');
+      final parent = todoListService.todos.single;
+      await todoListService.addSubtask(parent.id, 'Child');
+
+      await todoListService.deleteTodoById(parent.id);
+
+      expect(todoListService.todos, isEmpty);
+    });
+
+    test('adding a subtask reopens a completed parent', () async {
+      await todoListService.addTodo('Project');
+      final parent = todoListService.todos.single;
+      await todoListService.addSubtask(parent.id, 'Child');
+      final child = todoListService.childrenOf(parent.id).single;
+      await todoListService.toggleTodoById(child.id);
+      expect(todoListService.todoById(parent.id)!.isCompleted, isTrue);
+
+      await todoListService.addSubtask(parent.id, 'New child');
+
+      expect(todoListService.todoById(parent.id)!.isCompleted, isFalse);
+      expect(todoListService.childrenOf(parent.id), hasLength(2));
+    });
+
     test('keeps lists isolated without referring to desktop windows', () async {
       final anotherList = TodoListService(TodoListId.create());
       await anotherList.ready;

--- a/test/todo_model_test.dart
+++ b/test/todo_model_test.dart
@@ -22,7 +22,11 @@ void main() {
       });
 
       test('should accept custom ID', () {
-        final todo = Todo(text: 'Test Task', isCompleted: false, id: 'custom_id');
+        final todo = Todo(
+          text: 'Test Task',
+          isCompleted: false,
+          id: 'custom_id',
+        );
 
         expect(todo.id, 'custom_id');
       });
@@ -38,7 +42,11 @@ void main() {
       late Todo originalTodo;
 
       setUp(() {
-        originalTodo = Todo(text: 'Original', isCompleted: false, id: 'test_id');
+        originalTodo = Todo(
+          text: 'Original',
+          isCompleted: false,
+          id: 'test_id',
+        );
       });
 
       test('should copy with new text', () {
@@ -124,6 +132,18 @@ void main() {
         expect(json.containsKey('isCompleted'), true);
         expect(json.containsKey('id'), true);
       });
+
+      test('should preserve parent relationship', () {
+        final todo = Todo(
+          text: 'Child task',
+          isCompleted: false,
+          id: 'child',
+          parentId: 'parent',
+        );
+
+        expect(todo.toJson()['parentId'], 'parent');
+        expect(Todo.fromJson(todo.toJson()).parentId, 'parent');
+      });
     });
 
     group('fromJson', () {
@@ -153,6 +173,16 @@ void main() {
         expect(todo.isCompleted, true);
       });
 
+      test('should load legacy todo without parent relationship', () {
+        final todo = Todo.fromJson({
+          'text': 'Legacy task',
+          'isCompleted': false,
+          'id': 'legacy',
+        });
+
+        expect(todo.parentId, isNull);
+      });
+
       test('should handle special characters in text', () {
         final json = {
           'text': 'Task with "quotes" and \\backslash',
@@ -168,7 +198,11 @@ void main() {
 
     group('JSON round-trip', () {
       test('should preserve data through toJson and fromJson', () {
-        final original = Todo(text: 'Round Trip', isCompleted: true, id: 'round_trip');
+        final original = Todo(
+          text: 'Round Trip',
+          isCompleted: true,
+          id: 'round_trip',
+        );
         final json = original.toJson();
         final restored = Todo.fromJson(json);
 


### PR DESCRIPTION
## Summary

Implements the subtask UX and behavior defined in #41.

- Adds one-level parent/child relationships with backward-compatible storage
- Adds inline subtask creation and task-name editing without modals
- Supports hover, right-click, and long-press task actions
- Adds parent/child completion synchronization and progress counters
- Keeps incomplete parent groups in the open list, including completed children
- Supports root-level and sibling-level reordering
- Deletes a parent and its subtasks together

## Validation

- `fvm flutter analyze`
- `fvm flutter test` (104 tests)
- `git diff --check`

Closes #41
