### PR TITLE
Polish subtask interactions

### DIFF
--- a/lib/widgets/molecules/todo_item.dart
+++ b/lib/widgets/molecules/todo_item.dart
@@ -88,6 +88,11 @@ class _TodoItemState extends State<TodoItem> {
         position.dy,
       ),
       items: [
+        if (widget.hasChildren && widget.onToggleExpanded != null)
+          PopupMenuItem(
+            value: 'collapse',
+            child: Text(widget.isExpanded ? '折りたたむ' : '展開する'),
+          ),
         if (widget.onAddSubtask != null)
           const PopupMenuItem(value: 'add', child: Text('サブタスクを追加')),
         if (widget.onEdit != null)
@@ -97,6 +102,8 @@ class _TodoItemState extends State<TodoItem> {
     ).then((value) {
       if (!mounted) return;
       switch (value) {
+        case 'collapse':
+          widget.onToggleExpanded?.call();
         case 'add':
           widget.onAddSubtask?.call();
         case 'edit':
@@ -152,18 +159,6 @@ class _TodoItemState extends State<TodoItem> {
             leading: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                if (widget.hasChildren)
-                  IconButton(
-                    icon: Icon(
-                      widget.isExpanded
-                          ? Icons.keyboard_arrow_down
-                          : Icons.chevron_right,
-                    ),
-                    onPressed: widget.onToggleExpanded,
-                    tooltip: widget.isExpanded ? '折りたたむ' : '展開する',
-                  )
-                else if (!widget.isSubtask)
-                  const SizedBox(width: 48),
                 AnimatedCheckbox(
                   value: widget.todo.isCompleted,
                   onChanged: (_) => widget.onToggle(),

--- a/lib/widgets/organisms/todo_list.dart
+++ b/lib/widgets/organisms/todo_list.dart
@@ -191,15 +191,18 @@ class _TodoListState extends State<TodoList> {
                   ),
               itemBuilder: (context, index) {
                 final child = children[index];
-                return TodoItem(
+                return Padding(
                   key: ValueKey(child.id),
-                  todo: child,
-                  isSubtask: true,
-                  onToggle: () => widget.onToggleTodo(child.id),
-                  onDelete: () => widget.onDeleteTodo(child.id),
-                  onEdit: (text) => widget.onEditTodo(child.id, text),
-                  reorderIndex: completed ? null : index,
-                  isCompleted: completed,
+                  padding: const EdgeInsets.only(left: 24, right: 24),
+                  child: TodoItem(
+                    todo: child,
+                    isSubtask: true,
+                    onToggle: () => widget.onToggleTodo(child.id),
+                    onDelete: () => widget.onDeleteTodo(child.id),
+                    onEdit: (text) => widget.onEditTodo(child.id, text),
+                    reorderIndex: completed ? null : index,
+                    isCompleted: completed,
+                  ),
                 );
               },
             ),
@@ -258,7 +261,6 @@ class _SubtaskInputState extends State<_SubtaskInput> {
     autofocus: true,
     decoration: const InputDecoration(hintText: 'サブタスクを追加…', isDense: true),
     onSubmitted: widget.onSubmit,
-    onEditingComplete: () => widget.onSubmit(_controller.text),
     onTapOutside: (_) => widget.onCancel(),
   );
 }

--- a/test/todo_list_service_test.dart
+++ b/test/todo_list_service_test.dart
@@ -79,6 +79,16 @@ void main() {
       expect(todoListService.todoById(parent.id)!.isCompleted, isFalse);
     });
 
+    test('adds one subtask exactly once', () async {
+      await todoListService.addTodo('Project');
+      final parent = todoListService.todos.single;
+
+      await todoListService.addSubtask(parent.id, 'Single child');
+
+      expect(todoListService.childrenOf(parent.id), hasLength(1));
+      expect(todoListService.childrenOf(parent.id).single.text, 'Single child');
+    });
+
     test('deleting a parent deletes its subtasks', () async {
       await todoListService.addTodo('Project');
       final parent = todoListService.todos.single;


### PR DESCRIPTION
## Summary

Implements the follow-up fixes requested in #43.

- Improves subtask hierarchy with narrower cards and additional horizontal indentation
- Fixes duplicate subtask creation caused by duplicate text-field completion callbacks
- Adds a regression test ensuring one subtask is created exactly once
- Moves collapse/expand into the task overflow menu and removes the separate chevron action

## Validation

- `fvm flutter analyze`
- `fvm flutter test` (105 tests)
- `fvm flutter build macos --debug`
- `git diff --check`

Closes #43
