### PR TITLE
Add tests for inline todo title editing

### DIFF
--- a/test/todo_list_service_test.dart
+++ b/test/todo_list_service_test.dart
@@ -36,6 +36,27 @@ void main() {
       expect(todoListService.todos, isEmpty);
     });
 
+    test('edits and persists a todo title by ID', () async {
+      await todoListService.addTodo('Original title');
+      final todoId = todoListService.todos.single.id;
+
+      await todoListService.updateTodoText(todoId, '  Updated title  ');
+
+      expect(todoListService.todoById(todoId)!.text, 'Updated title');
+      final reloadedService = TodoListService(listId);
+      await reloadedService.ready;
+      expect(reloadedService.todoById(todoId)!.text, 'Updated title');
+    });
+
+    test('does not replace a title with blank text', () async {
+      await todoListService.addTodo('Keep this title');
+      final todoId = todoListService.todos.single.id;
+
+      await todoListService.updateTodoText(todoId, '   ');
+
+      expect(todoListService.todoById(todoId)!.text, 'Keep this title');
+    });
+
     test('toggles, deletes, and reorders todos', () async {
       await todoListService.addTodo('First');
       await todoListService.addTodo('Second');


### PR DESCRIPTION
## Summary

Completes the verification work for #36.

The inline editing UI and persistence implementation are already available from #42. This PR adds regression coverage for the behavior:

- Persists an edited title by logical todo-list ID
- Trims edited titles
- Reloads the edited title successfully
- Rejects blank replacement titles without changing the existing title

## Validation

- `fvm flutter analyze`
- `fvm flutter test` (107 tests)
- `git diff --check`

Closes #36
