### PR TITLE
Show uncompleted task count

### DIFF
--- a/lib/widgets/organisms/todo_list.dart
+++ b/lib/widgets/organisms/todo_list.dart
@@ -62,16 +62,36 @@ class _TodoListState extends State<TodoList> {
       child: Column(
         children: [
           Expanded(
-            child: ReorderableListView.builder(
-              padding: const EdgeInsets.all(8),
-              buildDefaultDragHandles: false,
-              itemCount: openRoots.length,
-              onReorder:
-                  (oldIndex, newIndex) =>
-                      widget.onReorderSiblings?.call(null, oldIndex, newIndex),
-              itemBuilder:
-                  (context, index) =>
-                      _buildGroup(context, openRoots[index], index),
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(top: 8, bottom: 4),
+                  child: Text(
+                    'Uncompleted (${openRoots.length})',
+                    style: TextStyle(
+                      color: themeProvider.textColor,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: ReorderableListView.builder(
+                    padding: const EdgeInsets.all(8),
+                    buildDefaultDragHandles: false,
+                    itemCount: openRoots.length,
+                    onReorder:
+                        (oldIndex, newIndex) => widget.onReorderSiblings?.call(
+                          null,
+                          oldIndex,
+                          newIndex,
+                        ),
+                    itemBuilder:
+                        (context, index) =>
+                            _buildGroup(context, openRoots[index], index),
+                  ),
+                ),
+              ],
             ),
           ),
           if (completedRoots.isNotEmpty)

--- a/test/todo_list_widget_test.dart
+++ b/test/todo_list_widget_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsubusu/models/todo.dart';
+import 'package:tsubusu/providers/theme_provider.dart';
+import 'package:tsubusu/widgets/organisms/todo_list.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('shows the count of uncompleted top-level tasks', (tester) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => ThemeProvider(),
+        child: MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                TodoList(
+                  todos: [
+                    Todo(id: 'open-1', text: 'Open one', isCompleted: false),
+                    Todo(id: 'open-2', text: 'Open two', isCompleted: false),
+                    Todo(id: 'completed', text: 'Completed', isCompleted: true),
+                    Todo(
+                      id: 'child',
+                      text: 'Completed child',
+                      isCompleted: true,
+                      parentId: 'open-1',
+                    ),
+                  ],
+                  onToggleTodo: (_) {},
+                  onDeleteTodo: (_) {},
+                  onAddSubtask: (_, __) {},
+                  onEditTodo: (_, __) {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Uncompleted (2)'), findsOneWidget);
+    expect(find.text('Completed (1)'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Implements #46 by adding a task count to the uncompleted tasks zone.

- Displays `Uncompleted (N)` above the open task list
- Counts top-level tasks only, so subtasks are not double-counted
- Keeps the existing `Completed (N)` display
- Adds a widget test covering both zone counts and top-level counting

## Validation

- `fvm flutter analyze`
- `fvm flutter test` (108 tests)
- `git diff --check`

Closes #46
