### PR TITLE
Persist and restore todo list windows

### DIFF
--- a/lib/constants/storage_keys.dart
+++ b/lib/constants/storage_keys.dart
@@ -2,6 +2,8 @@ import '../models/todo_list_id.dart';
 
 class StorageKeys {
   static const String openWindows = 'open_windows';
+  static const String todoListCatalog = 'todo_list_catalog';
+  static const String openListIds = 'open_list_ids';
   static const String selectedTheme = 'selected_theme';
 
   /// Prefix used by releases before the todo-list persistence boundary.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:desktop_multi_window/desktop_multi_window.dart';
+import 'dart:convert';
+import 'models/todo_list_id.dart';
 import 'providers/theme_provider.dart';
 import 'services/window_manager.dart';
 import 'widgets/pages/todo_page.dart';
@@ -64,8 +66,21 @@ void main(List<String> args) {
   if (WindowManager.supportsWindowManagement &&
       args.firstOrNull == 'multi_window') {
     final windowId = int.parse(args[1]);
+    String? initialListId;
+    if (args.length > 2) {
+      try {
+        final windowArguments = jsonDecode(args[2]) as Map<String, dynamic>;
+        initialListId = windowArguments['listId'] as String?;
+      } catch (_) {
+        // Older windows may not have startup arguments.
+      }
+    }
     runApp(
-      TsubusuWindow(windowController: WindowController.fromWindowId(windowId)),
+      TsubusuWindow(
+        windowController: WindowController.fromWindowId(windowId),
+        initialListId:
+            initialListId == null ? null : TodoListId.fromValue(initialListId),
+      ),
     );
   } else {
     runApp(const TsubusuWindow());
@@ -74,8 +89,9 @@ void main(List<String> args) {
 
 class TsubusuWindow extends StatelessWidget {
   final WindowController? windowController;
+  final TodoListId? initialListId;
 
-  const TsubusuWindow({super.key, this.windowController});
+  const TsubusuWindow({super.key, this.windowController, this.initialListId});
 
   @override
   Widget build(BuildContext context) {
@@ -86,7 +102,10 @@ class TsubusuWindow extends StatelessWidget {
           return MaterialApp(
             title: 'Tsubusu',
             theme: themeProvider.themeData,
-            home: const TodoPage(),
+            home: TodoPage(
+              windowController: windowController,
+              initialListId: initialListId,
+            ),
             debugShowCheckedModeBanner: false,
           );
         },

--- a/lib/models/todo_list_id.dart
+++ b/lib/models/todo_list_id.dart
@@ -7,6 +7,13 @@ class TodoListId {
 
   const TodoListId._(this.value);
 
+  factory TodoListId.fromValue(String value) {
+    if (value.trim().isEmpty) {
+      throw ArgumentError.value(value, 'value', 'List ID cannot be empty');
+    }
+    return TodoListId._(value);
+  }
+
   factory TodoListId.create() {
     return TodoListId._('list_${DateTime.now().microsecondsSinceEpoch}');
   }

--- a/lib/models/todo_list_record.dart
+++ b/lib/models/todo_list_record.dart
@@ -1,0 +1,24 @@
+import 'todo_list_id.dart';
+
+class TodoListRecord {
+  final TodoListId id;
+  final String title;
+
+  const TodoListRecord({required this.id, required this.title});
+
+  TodoListRecord copyWith({TodoListId? id, String? title}) {
+    return TodoListRecord(id: id ?? this.id, title: title ?? this.title);
+  }
+
+  Map<String, dynamic> toJson() => {'id': id.value, 'title': title};
+
+  factory TodoListRecord.fromJson(Map<String, dynamic> json) {
+    return TodoListRecord(
+      id: TodoListId.fromValue(json['id'] as String),
+      title:
+          (json['title'] as String?)?.trim().isNotEmpty == true
+              ? (json['title'] as String).trim()
+              : 'tsubusu',
+    );
+  }
+}

--- a/lib/services/todo_list_catalog_service.dart
+++ b/lib/services/todo_list_catalog_service.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../constants/storage_keys.dart';
+import '../models/todo_list_id.dart';
+import '../models/todo_list_record.dart';
+
+class TodoListCatalogService {
+  static const defaultTitle = 'tsubusu';
+
+  Future<List<TodoListRecord>> loadLists() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    final encoded = prefs.getString(StorageKeys.todoListCatalog);
+    if (encoded != null) {
+      final decoded = jsonDecode(encoded) as List<dynamic>;
+      return decoded
+          .map((item) => TodoListRecord.fromJson(item as Map<String, dynamic>))
+          .toList();
+    }
+
+    final migrated = _discoverPersistedLists(prefs);
+    if (migrated.isNotEmpty) {
+      await _saveLists(prefs, migrated);
+    }
+    return migrated;
+  }
+
+  Future<TodoListRecord> ensureDefaultList() async {
+    final lists = await loadLists();
+    if (lists.isNotEmpty) return lists.first;
+    return createList();
+  }
+
+  Future<TodoListRecord> createList({String title = defaultTitle}) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    final lists = await _loadListsFromPreferences(prefs);
+    final record = TodoListRecord(
+      id: TodoListId.create(),
+      title: title.trim().isEmpty ? defaultTitle : title.trim(),
+    );
+    lists.add(record);
+    await _saveLists(prefs, lists);
+    return record;
+  }
+
+  Future<void> updateTitle(TodoListId id, String title) async {
+    final normalized = title.trim();
+    if (normalized.isEmpty) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    final lists = await _loadListsFromPreferences(prefs);
+    final index = lists.indexWhere((list) => list.id == id);
+    if (index == -1) return;
+    lists[index] = lists[index].copyWith(title: normalized);
+    await _saveLists(prefs, lists);
+  }
+
+  Future<void> deleteList(TodoListId id) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    final lists = await _loadListsFromPreferences(prefs);
+    lists.removeWhere((list) => list.id == id);
+    await _saveLists(prefs, lists);
+
+    await prefs.remove(StorageKeys.todosForList(id));
+    final openListIds = prefs.getStringList(StorageKeys.openListIds) ?? [];
+    openListIds.remove(id.value);
+    await prefs.setStringList(StorageKeys.openListIds, openListIds);
+  }
+
+  Future<List<TodoListRecord>> _loadListsFromPreferences(
+    SharedPreferences prefs,
+  ) async {
+    final encoded = prefs.getString(StorageKeys.todoListCatalog);
+    if (encoded == null) return _discoverPersistedLists(prefs);
+    final decoded = jsonDecode(encoded) as List<dynamic>;
+    return decoded
+        .map((item) => TodoListRecord.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  List<TodoListRecord> _discoverPersistedLists(SharedPreferences prefs) {
+    final ids =
+        prefs
+            .getKeys()
+            .where((key) => key.startsWith('todos_list_'))
+            .map((key) => key.substring('todos_list_'.length))
+            .where((value) => value.isNotEmpty)
+            .toSet()
+            .toList()
+          ..sort();
+
+    return [
+      for (var i = 0; i < ids.length; i++)
+        TodoListRecord(
+          id: TodoListId.fromValue(ids[i]),
+          title: i == 0 ? defaultTitle : '$defaultTitle ${i + 1}',
+        ),
+    ];
+  }
+
+  Future<void> _saveLists(
+    SharedPreferences prefs,
+    List<TodoListRecord> lists,
+  ) async {
+    await prefs.setString(
+      StorageKeys.todoListCatalog,
+      jsonEncode(lists.map((list) => list.toJson()).toList()),
+    );
+  }
+}

--- a/lib/services/window_manager.dart
+++ b/lib/services/window_manager.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'dart:convert';
+import 'package:desktop_multi_window/desktop_multi_window.dart';
 
 class WindowManager {
+  static const _channel = MethodChannel('tsubusu/window_manager');
+  static Future<void> Function()? _newWindowHandler;
+
   static bool get supportsWindowManagement =>
       isDesktopPlatform(defaultTargetPlatform);
 
@@ -11,15 +16,37 @@ class WindowManager {
         platform == TargetPlatform.windows;
   }
 
+  static void registerMainWindowHandlers({
+    required Future<void> Function() onNewWindow,
+  }) {
+    _newWindowHandler = onNewWindow;
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'newWindow') {
+        await _newWindowHandler?.call();
+      }
+    });
+  }
+
+  static Future<WindowController> createWindow({
+    required String listId,
+    required String title,
+  }) async {
+    final controller = await DesktopMultiWindow.createWindow(
+      jsonEncode({'listId': listId}),
+    );
+    await controller.setFrameAutosaveName('tsubusu_$listId');
+    await controller.setTitle(title);
+    await controller.show();
+    return controller;
+  }
+
   static Future<void> updateWindowTitle(String title) async {
     if (!supportsWindowManagement) {
       return;
     }
 
     try {
-      const MethodChannel(
-        'tsubusu/window_manager',
-      ).invokeMethod('updateWindowTitle', {'title': title});
+      await _channel.invokeMethod('updateWindowTitle', {'title': title});
     } catch (e) {
       debugPrint('Failed to update window title: $e');
     }

--- a/lib/services/window_registry_service.dart
+++ b/lib/services/window_registry_service.dart
@@ -14,6 +14,7 @@ class WindowRegistryService {
   /// Registers a window as open
   static Future<void> registerWindow(String windowId) async {
     final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
     final openWindows = prefs.getStringList(StorageKeys.openWindows) ?? [];
 
     if (!openWindows.contains(windowId)) {
@@ -25,6 +26,7 @@ class WindowRegistryService {
   /// Unregisters a window when it's closed
   static Future<void> unregisterWindow(String windowId) async {
     final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
     final openWindows = prefs.getStringList(StorageKeys.openWindows) ?? [];
 
     openWindows.remove(windowId);
@@ -34,8 +36,12 @@ class WindowRegistryService {
   /// Gets the window title based on the position in the currently open windows list
   /// This ensures window titles are always sequential (tsubusu, tsubusu 2, tsubusu 3)
   /// regardless of the internal window IDs
-  static Future<String> getWindowTitle(String windowId, {String defaultName = 'tsubusu'}) async {
+  static Future<String> getWindowTitle(
+    String windowId, {
+    String defaultName = 'tsubusu',
+  }) async {
     final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
     final openWindows = prefs.getStringList(StorageKeys.openWindows) ?? [];
 
     // Find the position of this window in the open windows list
@@ -46,5 +52,30 @@ class WindowRegistryService {
     }
 
     return '$defaultName $position';
+  }
+
+  static Future<List<String>> getOpenListIds() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    return prefs.getStringList(StorageKeys.openListIds) ?? [];
+  }
+
+  static Future<void> registerOpenList(String listId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    final openListIds = prefs.getStringList(StorageKeys.openListIds) ?? [];
+    if (!openListIds.contains(listId)) {
+      openListIds.add(listId);
+      await prefs.setStringList(StorageKeys.openListIds, openListIds);
+    }
+  }
+
+  static Future<void> unregisterOpenList(String listId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    final openListIds = prefs.getStringList(StorageKeys.openListIds) ?? [];
+    if (openListIds.remove(listId)) {
+      await prefs.setStringList(StorageKeys.openListIds, openListIds);
+    }
   }
 }

--- a/lib/widgets/organisms/app_header.dart
+++ b/lib/widgets/organisms/app_header.dart
@@ -8,6 +8,7 @@ class AppHeader extends StatefulWidget {
   final FocusNode focusNode;
   final VoidCallback onAddTodo;
   final VoidCallback onShowSettings;
+  final VoidCallback onShowLists;
   final String windowTitle;
   final ValueChanged<String> onTitleChanged;
 
@@ -17,6 +18,7 @@ class AppHeader extends StatefulWidget {
     required this.focusNode,
     required this.onAddTodo,
     required this.onShowSettings,
+    required this.onShowLists,
     required this.windowTitle,
     required this.onTitleChanged,
   });
@@ -38,7 +40,8 @@ class _AppHeaderState extends State<AppHeader> {
   @override
   void didUpdateWidget(AppHeader oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.windowTitle != widget.windowTitle && _titleController.text != widget.windowTitle) {
+    if (oldWidget.windowTitle != widget.windowTitle &&
+        _titleController.text != widget.windowTitle) {
       _titleController.removeListener(_onTextChanged);
       _titleController.text = widget.windowTitle;
       _titleController.addListener(_onTextChanged);
@@ -87,7 +90,10 @@ class _AppHeaderState extends State<AppHeader> {
                     ),
                     decoration: const InputDecoration(
                       border: InputBorder.none,
-                      contentPadding: EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+                      contentPadding: EdgeInsets.symmetric(
+                        horizontal: 4,
+                        vertical: 4,
+                      ),
                       isDense: true,
                       hintText: 'Enter title...',
                       hintStyle: TextStyle(
@@ -105,12 +111,23 @@ class _AppHeaderState extends State<AppHeader> {
                 ),
               ),
               const SizedBox(width: 10),
+              IconButtonAtom(
+                icon: Icons.view_list,
+                onPressed: widget.onShowLists,
+                iconColor: Colors.white,
+                backgroundColor: Colors.white.withValues(
+                  alpha: DesignConstants.opacityLight,
+                ),
+              ),
+              const SizedBox(width: 6),
               // Settings button
               IconButtonAtom(
                 icon: Icons.settings,
                 onPressed: widget.onShowSettings,
                 iconColor: Colors.white,
-                backgroundColor: Colors.white.withValues(alpha: DesignConstants.opacityLight),
+                backgroundColor: Colors.white.withValues(
+                  alpha: DesignConstants.opacityLight,
+                ),
               ),
             ],
           ),

--- a/lib/widgets/pages/todo_page.dart
+++ b/lib/widgets/pages/todo_page.dart
@@ -1,14 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:desktop_multi_window/desktop_multi_window.dart';
 import '../../models/todo_list_id.dart';
+import '../../models/todo_list_record.dart';
 import '../../services/window_registry_service.dart';
 import '../../services/todo_list_service.dart';
+import '../../services/todo_list_catalog_service.dart';
 import '../../services/window_manager.dart';
 import '../organisms/app_header.dart';
 import '../organisms/todo_list.dart';
 import '../molecules/settings_dialog.dart';
 
 class TodoPage extends StatefulWidget {
-  const TodoPage({super.key});
+  final WindowController? windowController;
+  final TodoListId? initialListId;
+
+  const TodoPage({super.key, this.windowController, this.initialListId});
 
   @override
   State<TodoPage> createState() => _TodoPageState();
@@ -18,8 +24,9 @@ class _TodoPageState extends State<TodoPage> {
   final TextEditingController _controller = TextEditingController();
   final FocusNode _focusNode = FocusNode();
   TodoListService? _todoService;
-  String? _windowId;
   String _windowTitle = 'Tsubusu';
+  TodoListId? _listId;
+  final _catalog = TodoListCatalogService();
   bool _isInitialized = false;
 
   @override
@@ -29,15 +36,36 @@ class _TodoPageState extends State<TodoPage> {
   }
 
   Future<void> _initializeWindow() async {
+    final lists = await _catalog.loadLists();
+    TodoListRecord? selectedList;
+    if (widget.initialListId != null) {
+      for (final list in lists) {
+        if (list.id == widget.initialListId) selectedList = list;
+      }
+    } else if (WindowManager.supportsWindowManagement) {
+      final openListIds = await WindowRegistryService.getOpenListIds();
+      for (final list in lists) {
+        if (openListIds.contains(list.id.value)) {
+          selectedList ??= list;
+        }
+      }
+    }
+    selectedList ??= await _catalog.ensureDefaultList();
+    _listId = selectedList.id;
+    _windowTitle = selectedList.title;
+
     if (WindowManager.supportsWindowManagement) {
-      final windowId = await WindowRegistryService.getNextAvailableWindowId();
-      _windowId = windowId;
-      await WindowRegistryService.registerWindow(windowId);
+      await WindowRegistryService.registerOpenList(_listId!.value);
+      if (widget.windowController != null) {
+        await widget.windowController!.setFrameAutosaveName(
+          'tsubusu_${_listId!.value}',
+        );
+      } else {
+        WindowManager.registerMainWindowHandlers(onNewWindow: _createNewWindow);
+      }
     }
 
-    // A desktop window presents a logical list; it does not own the list's
-    // identity or persistence. Mobile can create and present TodoListIds too.
-    final todoService = TodoListService(TodoListId.create());
+    final todoService = TodoListService(_listId!);
     _todoService = todoService;
     await todoService.ready;
 
@@ -46,17 +74,24 @@ class _TodoPageState extends State<TodoPage> {
       return;
     }
 
-    if (_windowId != null) {
-      // Window registration and native title changes are desktop-only.
-      _windowTitle = await WindowRegistryService.getWindowTitle(_windowId!);
+    if (WindowManager.supportsWindowManagement) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        WindowManager.updateWindowTitle(_windowTitle);
+        if (widget.windowController != null) {
+          widget.windowController!.setTitle(_windowTitle);
+        } else {
+          WindowManager.updateWindowTitle(_windowTitle);
+        }
       });
     }
 
     setState(() {
       _isInitialized = true;
     });
+
+    if (widget.windowController == null &&
+        WindowManager.supportsWindowManagement) {
+      await _restoreAdditionalWindows();
+    }
   }
 
   @override
@@ -69,8 +104,163 @@ class _TodoPageState extends State<TodoPage> {
   }
 
   Future<void> _removeFromOpenWindows() async {
-    if (_windowId != null) {
-      await WindowRegistryService.unregisterWindow(_windowId!);
+    if (_listId != null && widget.windowController != null) {
+      await WindowRegistryService.unregisterOpenList(_listId!.value);
+    }
+  }
+
+  Future<void> _restoreAdditionalWindows() async {
+    final openListIds = await WindowRegistryService.getOpenListIds();
+    final currentListId = _listId!.value;
+    for (final listId in openListIds.where((id) => id != currentListId)) {
+      final lists = await _catalog.loadLists();
+      final matching = lists.where((list) => list.id.value == listId);
+      if (matching.isEmpty) continue;
+      await WindowManager.createWindow(
+        listId: listId,
+        title: matching.first.title,
+      );
+    }
+  }
+
+  Future<void> _createNewWindow() async {
+    final newList = await _catalog.createList();
+    await WindowRegistryService.registerOpenList(newList.id.value);
+    await WindowManager.createWindow(
+      listId: newList.id.value,
+      title: newList.title,
+    );
+  }
+
+  Future<void> _switchList(TodoListId listId) async {
+    if (_listId == listId) return;
+    final lists = await _catalog.loadLists();
+    final selected = lists.where((list) => list.id == listId).firstOrNull;
+    if (selected == null || !mounted) return;
+
+    final previousListId = _listId;
+    final previousService = _todoService;
+    if (WindowManager.supportsWindowManagement && previousListId != null) {
+      await WindowRegistryService.unregisterOpenList(previousListId.value);
+      await WindowRegistryService.registerOpenList(listId.value);
+    }
+
+    final nextService = TodoListService(listId);
+    _todoService = nextService;
+    _listId = listId;
+    _windowTitle = selected.title;
+    await nextService.ready;
+    previousService?.dispose();
+    if (!mounted) return;
+    setState(() {});
+    if (widget.windowController != null) {
+      await widget.windowController!.setTitle(_windowTitle);
+    } else if (WindowManager.supportsWindowManagement) {
+      await WindowManager.updateWindowTitle(_windowTitle);
+    }
+  }
+
+  Future<void> _showLists() async {
+    final selectedListId = await showDialog<TodoListId>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('Todo lists'),
+          content: SizedBox(
+            width: 320,
+            child: FutureBuilder<List<TodoListRecord>>(
+              future: _catalog.loadLists(),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const SizedBox(
+                    height: 100,
+                    child: Center(child: CircularProgressIndicator()),
+                  );
+                }
+                final lists = snapshot.data!;
+                return ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: lists.length,
+                  itemBuilder: (context, index) {
+                    final list = lists[index];
+                    return ListTile(
+                      selected: list.id == _listId,
+                      leading: const Icon(Icons.check_box_outlined),
+                      title: Text(list.title),
+                      onTap: () => Navigator.pop(dialogContext, list.id),
+                      trailing: IconButton(
+                        icon: const Icon(Icons.delete_outline),
+                        tooltip: 'Delete list',
+                        onPressed: () async {
+                          if (lists.length == 1) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('At least one list must remain.'),
+                              ),
+                            );
+                            return;
+                          }
+                          final confirmed = await showDialog<bool>(
+                            context: dialogContext,
+                            builder:
+                                (context) => AlertDialog(
+                                  title: const Text('Delete list?'),
+                                  content: Text(
+                                    'Delete "${list.title}" and all of its tasks?',
+                                  ),
+                                  actions: [
+                                    TextButton(
+                                      onPressed:
+                                          () => Navigator.pop(context, false),
+                                      child: const Text('Cancel'),
+                                    ),
+                                    FilledButton(
+                                      onPressed:
+                                          () => Navigator.pop(context, true),
+                                      child: const Text('Delete'),
+                                    ),
+                                  ],
+                                ),
+                          );
+                          if (confirmed != true) return;
+                          await _catalog.deleteList(list.id);
+                          if (!dialogContext.mounted) return;
+                          if (list.id == _listId) {
+                            final fallback = lists.firstWhere(
+                              (candidate) => candidate.id != list.id,
+                            );
+                            Navigator.pop(dialogContext, fallback.id);
+                          } else {
+                            Navigator.pop(dialogContext);
+                          }
+                        },
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () async {
+                final newList = await _catalog.createList();
+                if (dialogContext.mounted) {
+                  Navigator.pop(dialogContext, newList.id);
+                }
+              },
+              child: const Text('New list'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: const Text('Close'),
+            ),
+          ],
+        );
+      },
+    );
+    if (selectedListId != null && mounted) {
+      await _switchList(selectedListId);
     }
   }
 
@@ -106,8 +296,15 @@ class _TodoPageState extends State<TodoPage> {
     setState(() {
       _windowTitle = newTitle;
     });
+    if (_listId != null) {
+      _catalog.updateTitle(_listId!, newTitle);
+    }
     // Update the actual window title
-    WindowManager.updateWindowTitle(newTitle);
+    if (widget.windowController != null) {
+      widget.windowController!.setTitle(newTitle);
+    } else {
+      WindowManager.updateWindowTitle(newTitle);
+    }
   }
 
   void _showSettings() {
@@ -133,6 +330,7 @@ class _TodoPageState extends State<TodoPage> {
               focusNode: _focusNode,
               onAddTodo: _addTodo,
               onShowSettings: _showSettings,
+              onShowLists: _showLists,
               windowTitle: _windowTitle,
               onTitleChanged: _onTitleChanged,
             ),

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -5,6 +5,7 @@ import FlutterMacOS
 class AppDelegate: FlutterAppDelegate {
   private var windowCounter = 1
   private var windowControllers: [NSWindowController] = []
+  private var mainWindowChannel: FlutterMethodChannel?
   override func applicationDidFinishLaunching(_ aNotification: Notification) {
     super.applicationDidFinishLaunching(aNotification)
     setupMenuBar()
@@ -129,52 +130,9 @@ class AppDelegate: FlutterAppDelegate {
   }
   
   @objc private func newWindow() {
-    // Increment counter for new window
-    windowCounter += 1
-    
-    // Calculate offset position for new windows (cascade effect)
-    let offsetX = 100 + (windowCounter - 1) * 30
-    let offsetY = 100 + (windowCounter - 1) * 30
-    
-    // Create new window with proper Flutter setup
-    let newWindow = NSWindow(
-      contentRect: NSRect(x: offsetX, y: offsetY, width: 300, height: 400),
-      styleMask: [.titled, .closable, .miniaturizable, .resizable],
-      backing: .buffered,
-      defer: false
-    )
-    
-    let flutterViewController = FlutterViewController()
-    newWindow.contentViewController = flutterViewController
-    
-    // Configure window with title bar visible and numbered name
-    newWindow.titlebarAppearsTransparent = false
-    newWindow.titleVisibility = .visible
-    newWindow.title = "tsubusu \(windowCounter)"
-    newWindow.minSize = NSSize(width: 250, height: 300)
-    newWindow.maxSize = NSSize(width: 600, height: 800)
-    
-    // Ensure window is at normal zoom level
-    newWindow.setIsZoomed(false)
-    
-    // Explicitly set the content size to ensure proper dimensions
-    newWindow.setContentSize(NSSize(width: 300, height: 400))
-    
-    RegisterGeneratedPlugins(registry: flutterViewController)
-    
-    // Set up method channel for this window
-    setupMethodChannel(for: flutterViewController, window: newWindow)
-    
-    // Create window controller to manage the window independently
-    let windowController = NSWindowController(window: newWindow)
-    windowControllers.append(windowController)
-    
-    // Ensure window is not minimized and is properly displayed
-    newWindow.deminiaturize(nil)
-    newWindow.orderFront(nil)
-    newWindow.makeKeyAndOrderFront(nil)
-    
-    windowController.showWindow(nil)
+    // The Dart side creates the window so it can allocate and persist a list ID
+    // before passing it to desktop_multi_window.
+    mainWindowChannel?.invokeMethod("newWindow", arguments: nil)
   }
   
   private func setupMainWindowMethodChannel() {
@@ -189,6 +147,10 @@ class AppDelegate: FlutterAppDelegate {
       name: "tsubusu/window_manager",
       binaryMessenger: flutterViewController.engine.binaryMessenger
     )
+
+    if window === NSApplication.shared.mainWindow {
+      mainWindowChannel = methodChannel
+    }
     
     methodChannel.setMethodCallHandler { [weak window] (call, result) in
       switch call.method {

--- a/test/todo_list_catalog_service_test.dart
+++ b/test/todo_list_catalog_service_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsubusu/constants/storage_keys.dart';
+import 'package:tsubusu/models/todo_list_id.dart';
+import 'package:tsubusu/services/todo_list_catalog_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TodoListCatalogService', () {
+    late TodoListCatalogService catalog;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      catalog = TodoListCatalogService();
+    });
+
+    test('persists the default list and reloads it', () async {
+      final created = await catalog.ensureDefaultList();
+      final reloaded = await TodoListCatalogService().loadLists();
+
+      expect(reloaded, hasLength(1));
+      expect(reloaded.single.id, created.id);
+      expect(reloaded.single.title, 'tsubusu');
+    });
+
+    test('persists title updates', () async {
+      final created = await catalog.createList(title: 'Work');
+
+      await catalog.updateTitle(created.id, '  Personal  ');
+
+      expect((await catalog.loadLists()).single.title, 'Personal');
+    });
+
+    test('discovers existing todo list keys from pre-catalog data', () async {
+      const listId = 'list_existing';
+      SharedPreferences.setMockInitialValues({'todos_list_$listId': '[]'});
+
+      final lists = await catalog.loadLists();
+
+      expect(lists.single.id, TodoListId.fromValue(listId));
+      expect(
+        (await SharedPreferences.getInstance()).getString(
+          StorageKeys.todoListCatalog,
+        ),
+        isNotNull,
+      );
+    });
+
+    test('deletes a list, its tasks, and its open session entry', () async {
+      final created = await catalog.createList();
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(StorageKeys.todosForList(created.id), '[{}]');
+      await prefs.setStringList(StorageKeys.openListIds, [created.id.value]);
+
+      await catalog.deleteList(created.id);
+
+      expect((await catalog.loadLists()), isEmpty);
+      expect(prefs.getString(StorageKeys.todosForList(created.id)), isNull);
+      expect(prefs.getStringList(StorageKeys.openListIds), isEmpty);
+    });
+  });
+}

--- a/test/window_registry_service_test.dart
+++ b/test/window_registry_service_test.dart
@@ -159,5 +159,17 @@ void main() {
         expect(title, 'tsubusu'); // Returns default when not found (position = 0 + 1 = 1)
       });
     });
+
+    test('registers and unregisters persistent open list IDs', () async {
+      await WindowRegistryService.registerOpenList('list_a');
+      await WindowRegistryService.registerOpenList('list_b');
+      await WindowRegistryService.registerOpenList('list_a');
+
+      expect(await WindowRegistryService.getOpenListIds(), ['list_a', 'list_b']);
+
+      await WindowRegistryService.unregisterOpenList('list_a');
+
+      expect(await WindowRegistryService.getOpenListIds(), ['list_b']);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Closes #49.

This PR persists todo list identities separately from desktop window identities and restores the previous desktop workspace after an app or Mac restart.

## What changed

- Added a persistent todo list catalog with stable list IDs and titles.
- Restored the list associated with the main window and recreated additional desktop windows from the saved session.
- Routed new macOS windows through `desktop_multi_window` with explicit list IDs.
- Added a shared list selector for desktop and smartphone layouts.
- Added explicit list deletion with confirmation; closing a window does not delete tasks.
- Added migration/discovery for existing `todos_list_*` storage.
- Added persistence and session registry tests.

## Validation

- `fvm flutter analyze`
- `fvm flutter test`
- `fvm flutter build macos --debug`

All checks passed.