### PR TITLE
Fix card body tap animation

### DIFF
--- a/lib/widgets/atoms/animated_checkbox.dart
+++ b/lib/widgets/atoms/animated_checkbox.dart
@@ -16,10 +16,10 @@ class AnimatedCheckbox extends StatefulWidget {
   });
 
   @override
-  State<AnimatedCheckbox> createState() => _AnimatedCheckboxState();
+  State<AnimatedCheckbox> createState() => AnimatedCheckboxState();
 }
 
-class _AnimatedCheckboxState extends State<AnimatedCheckbox>
+class AnimatedCheckboxState extends State<AnimatedCheckbox>
     with TickerProviderStateMixin {
   late AnimationController _squeezeController;
   late AnimationController _popController;
@@ -31,45 +31,51 @@ class _AnimatedCheckboxState extends State<AnimatedCheckbox>
   @override
   void initState() {
     super.initState();
-    
+
     // Squeeze animation controller for simple crush effect
     _squeezeController = AnimationController(
       duration: const Duration(milliseconds: 500), // Smooth crush duration
       vsync: this,
     );
-    
+
     // Pop animation controller for star burst effect
     _popController = AnimationController(
       duration: const Duration(milliseconds: 300), // Star flight duration
       vsync: this,
     );
-    
+
     // Simple height squeeze animation for "tsubusu" effect
     _squeezeAnimation = Tween<double>(
       begin: 1.0,
       end: 0.05, // Crush down to 5% height
-    ).animate(CurvedAnimation(
-      parent: _squeezeController,
-      curve: Curves.easeInCubic, // Accelerating crush feeling
-    ));
+    ).animate(
+      CurvedAnimation(
+        parent: _squeezeController,
+        curve: Curves.easeInCubic, // Accelerating crush feeling
+      ),
+    );
 
     // Star burst distance animation - stars fly outward
     _popScaleAnimation = Tween<double>(
-      begin: 0.0,  // Start from center
-      end: 50.0,   // Fly out 50 pixels from center
-    ).animate(CurvedAnimation(
-      parent: _popController,
-      curve: Curves.easeOutCubic, // Smooth deceleration as they fly out
-    ));
+      begin: 0.0, // Start from center
+      end: 50.0, // Fly out 50 pixels from center
+    ).animate(
+      CurvedAnimation(
+        parent: _popController,
+        curve: Curves.easeOutCubic, // Smooth deceleration as they fly out
+      ),
+    );
 
     // Star opacity animation - fade out during flight
     _popOpacityAnimation = Tween<double>(
       begin: 1.0, // Fully visible
-      end: 0.0,   // Fade to transparent
-    ).animate(CurvedAnimation(
-      parent: _popController,
-      curve: Curves.easeOut, // Fade out quickly
-    ));
+      end: 0.0, // Fade to transparent
+    ).animate(
+      CurvedAnimation(
+        parent: _popController,
+        curve: Curves.easeOut, // Fade out quickly
+      ),
+    );
   }
 
   @override
@@ -79,26 +85,32 @@ class _AnimatedCheckboxState extends State<AnimatedCheckbox>
     super.dispose();
   }
 
+  void animateCheck() {
+    _animateCheck();
+  }
+
   void _animateCheck() async {
     // For static mode (completed items), just toggle immediately
     if (widget.isStatic) {
       widget.onChanged?.call(!widget.value);
       return;
     }
-    
+
     // Prevent multiple simultaneous animations
     if (_isAnimating) return;
-    
+
     if (!widget.value) {
       setState(() {
         _isAnimating = true;
       });
-      
+
       try {
         // Execute simple crush followed by balloon pop effect
         await _squeezeController.forward(); // Simple crush animation
         await _executePopEffect(); // Balloon burst effect
-        widget.onChanged?.call(true); // Trigger state change after animation completes
+        widget.onChanged?.call(
+          true,
+        ); // Trigger state change after animation completes
       } finally {
         if (mounted) {
           setState(() {
@@ -118,10 +130,10 @@ class _AnimatedCheckboxState extends State<AnimatedCheckbox>
   Future<void> _executePopEffect() async {
     // Brief pause before pop effect
     await Future.delayed(const Duration(milliseconds: 50));
-    
+
     // Quick outward burst effect to simulate balloon pop
     await _popController.forward();
-    
+
     // Reset pop controller for next use
     _popController.reset();
   }
@@ -129,7 +141,7 @@ class _AnimatedCheckboxState extends State<AnimatedCheckbox>
   @override
   void didUpdateWidget(AnimatedCheckbox oldWidget) {
     super.didUpdateWidget(oldWidget);
-    
+
     // Only reset animations when this specific checkbox value changes externally
     // and it's being unchecked (not when other checkboxes trigger rebuilds)
     if (oldWidget.value != widget.value && !widget.value && !_isAnimating) {
@@ -149,18 +161,22 @@ class _AnimatedCheckboxState extends State<AnimatedCheckbox>
           double widthScale;
           double opacity = 1.0;
           Color? backgroundColor;
-          
+
           if (widget.isStatic) {
             // Static mode for completed items - always normal size
             heightScale = 1.0;
             widthScale = 1.0;
-            backgroundColor = widget.value 
-                ? (widget.activeColor ?? Colors.teal)
-                : Colors.grey[300];
+            backgroundColor =
+                widget.value
+                    ? (widget.activeColor ?? Colors.teal)
+                    : Colors.grey[300];
           } else if (_squeezeController.isAnimating) {
             // Squeezing animation
             heightScale = _squeezeAnimation.value;
-            widthScale = 1.0 + (1.0 - heightScale) * 0.2; // Slight width increase when squished
+            widthScale =
+                1.0 +
+                (1.0 - heightScale) *
+                    0.2; // Slight width increase when squished
             backgroundColor = Colors.grey[300];
           } else if (widget.value) {
             // Keep the completed state styling in compressed form
@@ -172,7 +188,7 @@ class _AnimatedCheckboxState extends State<AnimatedCheckbox>
             widthScale = 1.0;
             backgroundColor = Colors.grey[300];
           }
-          
+
           return SizedBox(
             width: 24,
             height: 24,
@@ -186,36 +202,44 @@ class _AnimatedCheckboxState extends State<AnimatedCheckbox>
                     opacity: opacity,
                     child: Transform(
                       alignment: Alignment.center,
-                      transform: Matrix4.identity()
-                        ..scale(widthScale, heightScale), // Scale based on animation state
+                      transform:
+                          Matrix4.identity()..scale(
+                            widthScale,
+                            heightScale,
+                          ), // Scale based on animation state
                       child: Container(
                         width: 24,
                         height: 24,
                         decoration: BoxDecoration(
-                        color: backgroundColor,
-                        borderRadius: BorderRadius.circular(DesignConstants.borderRadiusSmall),
-                        border: Border.all(
-                          color: widget.value 
-                              ? (widget.activeColor ?? Colors.teal)
-                              : Colors.grey[400]!,
-                          width: 2,
+                          color: backgroundColor,
+                          borderRadius: BorderRadius.circular(
+                            DesignConstants.borderRadiusSmall,
+                          ),
+                          border: Border.all(
+                            color:
+                                widget.value
+                                    ? (widget.activeColor ?? Colors.teal)
+                                    : Colors.grey[400]!,
+                            width: 2,
+                          ),
+                          boxShadow: [
+                            if (_squeezeController.isAnimating || widget.value)
+                              BoxShadow(
+                                color: (widget.activeColor ?? Colors.teal)
+                                    .withValues(alpha: 0.3),
+                                blurRadius: 8,
+                                spreadRadius: 2,
+                              ),
+                          ],
                         ),
-                        boxShadow: [
-                          if (_squeezeController.isAnimating || widget.value)
-                            BoxShadow(
-                              color: (widget.activeColor ?? Colors.teal).withValues(alpha: 0.3),
-                              blurRadius: 8,
-                              spreadRadius: 2,
-                            ),
-                        ],
-                      ),
-                      child: widget.value
-                          ? Icon(
-                              Icons.check,
-                              size: 16,
-                              color: Colors.white,
-                            )
-                          : null,
+                        child:
+                            widget.value
+                                ? Icon(
+                                  Icons.check,
+                                  size: 16,
+                                  color: Colors.white,
+                                )
+                                : null,
                       ),
                     ),
                   ),
@@ -259,20 +283,21 @@ class StarBurstPainter extends CustomPainter {
     if (progress == 0.0 || opacity == 0.0) return;
 
     final center = Offset(size.width / 2, size.height / 2);
-    final paint = Paint()
-      ..color = color.withValues(alpha: opacity)
-      ..style = PaintingStyle.fill;
+    final paint =
+        Paint()
+          ..color = color.withValues(alpha: opacity)
+          ..style = PaintingStyle.fill;
 
     // Draw stars flying outward from center
     for (int i = 0; i < starCount; i++) {
       final angle = (i / starCount) * 2 * math.pi;
       final distance = progress;
-      
+
       // Calculate star position
       final starX = center.dx + distance * math.cos(angle);
       final starY = center.dy + distance * math.sin(angle);
       final starCenter = Offset(starX, starY);
-      
+
       // Draw rotating star
       final rotation = progress * 6; // Multiple rotations during flight
       _drawStar(canvas, paint, starCenter, 5.0, rotation);
@@ -280,25 +305,31 @@ class StarBurstPainter extends CustomPainter {
   }
 
   // Draw a 5-pointed star
-  void _drawStar(Canvas canvas, Paint paint, Offset center, double radius, double rotation) {
+  void _drawStar(
+    Canvas canvas,
+    Paint paint,
+    Offset center,
+    double radius,
+    double rotation,
+  ) {
     final path = Path();
     const int points = 5;
     final double outerRadius = radius;
     final double innerRadius = radius * 0.4;
-    
+
     for (int i = 0; i < points * 2; i++) {
       final angle = (i * math.pi / points) + rotation;
       final r = (i % 2 == 0) ? outerRadius : innerRadius;
       final x = center.dx + r * math.cos(angle);
       final y = center.dy + r * math.sin(angle);
-      
+
       if (i == 0) {
         path.moveTo(x, y);
       } else {
         path.lineTo(x, y);
       }
     }
-    
+
     path.close();
     canvas.drawPath(path, paint);
   }

--- a/lib/widgets/molecules/todo_item.dart
+++ b/lib/widgets/molecules/todo_item.dart
@@ -43,8 +43,13 @@ class TodoItem extends StatefulWidget {
 class _TodoItemState extends State<TodoItem> {
   final _editController = TextEditingController();
   final _editFocusNode = FocusNode();
+  final _checkboxKey = GlobalKey<AnimatedCheckboxState>();
   bool _isHovered = false;
   bool _isEditing = false;
+
+  void _animateToggle() {
+    if (!_isEditing) _checkboxKey.currentState?.animateCheck();
+  }
 
   @override
   void dispose() {
@@ -129,6 +134,7 @@ class _TodoItemState extends State<TodoItem> {
       onEnter: (_) => setState(() => _isHovered = true),
       onExit: (_) => setState(() => _isHovered = false),
       child: GestureDetector(
+        onTap: _isEditing ? null : _animateToggle,
         onSecondaryTapUp:
             (details) => _showActions(context, details.globalPosition),
         onLongPress: () => _showActions(context),
@@ -160,6 +166,7 @@ class _TodoItemState extends State<TodoItem> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 AnimatedCheckbox(
+                  key: _checkboxKey,
                   value: widget.todo.isCompleted,
                   onChanged: (_) => widget.onToggle(),
                   activeColor: themeProvider.primaryColor,
@@ -210,7 +217,7 @@ class _TodoItemState extends State<TodoItem> {
                 ],
               ],
             ),
-            onTap: _isEditing ? null : widget.onToggle,
+            onTap: _isEditing ? null : _animateToggle,
           ),
         ),
       ),

--- a/test/todo_list_widget_test.dart
+++ b/test/todo_list_widget_test.dart
@@ -46,4 +46,40 @@ void main() {
     expect(find.text('Uncompleted (2)'), findsOneWidget);
     expect(find.text('Completed (1)'), findsOneWidget);
   });
+
+  testWidgets('animates and toggles when the card body is tapped', (
+    tester,
+  ) async {
+    String? toggledTodoId;
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => ThemeProvider(),
+        child: MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                TodoList(
+                  todos: [
+                    Todo(id: 'open-1', text: 'Open one', isCompleted: false),
+                  ],
+                  onToggleTodo: (id) => toggledTodoId = id,
+                  onDeleteTodo: (_) {},
+                  onAddSubtask: (_, __) {},
+                  onEditTodo: (_, __) {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(ListTile).first);
+    await tester.pump(const Duration(milliseconds: 400));
+
+    // The card body should use the same delayed animation path as the checkbox,
+    // rather than toggling immediately on tap.
+    expect(toggledTodoId, isNull);
+  });
 }


### PR DESCRIPTION
## Summary
- route Todo card body taps through the existing AnimatedCheckbox animation
- preserve edit mode behavior and checkbox handling
- add a widget test covering card body taps

## Root cause
The checkbox owned the tsubusu animation, while ListTile taps called the toggle callback directly.

## Validation
- fvm flutter analyze
- fvm flutter test