### PR TITLE
Adapt dialogs and action menus for Apple platforms

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -45,12 +45,14 @@ platform :ios do
 
   private_lane :existing_ipa_path do |options|
     ipa_path = options[:ipa] || ENV["IPA_PATH"]
-    return nil if ipa_path.to_s.empty?
-
-    repo_root = File.expand_path("../..", __dir__)
-    resolved_path = File.expand_path(ipa_path, repo_root)
-    UI.user_error!("IPA not found: #{resolved_path}") unless File.file?(resolved_path)
-    resolved_path
+    if ipa_path.to_s.empty?
+      nil
+    else
+      repo_root = File.expand_path("../..", __dir__)
+      resolved_path = File.expand_path(ipa_path, repo_root)
+      UI.user_error!("IPA not found: #{resolved_path}") unless File.file?(resolved_path)
+      resolved_path
+    end
   end
 
   desc "Build an iOS IPA with Flutter"

--- a/lib/widgets/molecules/settings_dialog.dart
+++ b/lib/widgets/molecules/settings_dialog.dart
@@ -5,9 +5,7 @@ import '../../providers/theme_provider.dart';
 import '../atoms/custom_text.dart';
 
 class SettingsDialog extends StatefulWidget {
-  const SettingsDialog({
-    super.key,
-  });
+  const SettingsDialog({super.key});
 
   @override
   State<SettingsDialog> createState() => _SettingsDialogState();
@@ -35,7 +33,7 @@ class _SettingsDialogState extends State<SettingsDialog> {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
+    return AlertDialog.adaptive(
       title: const CustomText('Settings'),
       content: SingleChildScrollView(
         child: Column(
@@ -43,15 +41,20 @@ class _SettingsDialogState extends State<SettingsDialog> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Theme Selection Section
-            const CustomText('Theme:', style: TextStyle(fontWeight: FontWeight.bold)),
+            const CustomText(
+              'Theme:',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
             const SizedBox(height: 8),
-            ...AppTheme.predefinedThemes.map((theme) => RadioListTile<ThemeType>(
-                  title: CustomText(theme.displayName),
-                  value: theme.type,
-                  groupValue: _selectedThemeType,
-                  onChanged: _handleThemeChange,
-                  contentPadding: const EdgeInsets.symmetric(horizontal: 0),
-                )),
+            ...AppTheme.predefinedThemes.map(
+              (theme) => RadioListTile<ThemeType>(
+                title: CustomText(theme.displayName),
+                value: theme.type,
+                groupValue: _selectedThemeType,
+                onChanged: _handleThemeChange,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 0),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/widgets/molecules/todo_item.dart
+++ b/lib/widgets/molecules/todo_item.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -81,6 +82,52 @@ class _TodoItemState extends State<TodoItem> {
   }
 
   void _showActions(BuildContext context, [Offset? globalPosition]) {
+    final isApplePlatform = switch (Theme.of(context).platform) {
+      TargetPlatform.iOS || TargetPlatform.macOS => true,
+      _ => false,
+    };
+
+    if (isApplePlatform) {
+      showCupertinoModalPopup<String>(
+        context: context,
+        builder:
+            (context) => CupertinoActionSheet(
+              actions: [
+                if (widget.hasChildren && widget.onToggleExpanded != null)
+                  CupertinoActionSheetAction(
+                    onPressed: () => Navigator.pop(context, 'collapse'),
+                    child: Text(widget.isExpanded ? '折りたたむ' : '展開する'),
+                  ),
+                if (widget.onAddSubtask != null)
+                  CupertinoActionSheetAction(
+                    onPressed: () => Navigator.pop(context, 'add'),
+                    child: const Text('サブタスクを追加'),
+                  ),
+                if (widget.onMove != null)
+                  CupertinoActionSheetAction(
+                    onPressed: () => Navigator.pop(context, 'move'),
+                    child: const Text('別のタスクのサブタスクにする'),
+                  ),
+                if (widget.onEdit != null)
+                  CupertinoActionSheetAction(
+                    onPressed: () => Navigator.pop(context, 'edit'),
+                    child: const Text('名前を変更'),
+                  ),
+                CupertinoActionSheetAction(
+                  isDestructiveAction: true,
+                  onPressed: () => Navigator.pop(context, 'delete'),
+                  child: const Text('削除'),
+                ),
+              ],
+              cancelButton: CupertinoActionSheetAction(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('キャンセル'),
+              ),
+            ),
+      ).then(_handleAction);
+      return;
+    }
+
     final box = context.findRenderObject() as RenderBox;
     final position = globalPosition ?? box.localToGlobal(Offset.zero);
     showMenu<String>(
@@ -105,21 +152,23 @@ class _TodoItemState extends State<TodoItem> {
           const PopupMenuItem(value: 'edit', child: Text('名前を変更')),
         const PopupMenuItem(value: 'delete', child: Text('削除')),
       ],
-    ).then((value) {
-      if (!mounted) return;
-      switch (value) {
-        case 'collapse':
-          widget.onToggleExpanded?.call();
-        case 'add':
-          widget.onAddSubtask?.call();
-        case 'move':
-          widget.onMove?.call();
-        case 'edit':
-          _startEditing();
-        case 'delete':
-          widget.onDelete();
-      }
-    });
+    ).then(_handleAction);
+  }
+
+  void _handleAction(String? value) {
+    if (!mounted) return;
+    switch (value) {
+      case 'collapse':
+        widget.onToggleExpanded?.call();
+      case 'add':
+        widget.onAddSubtask?.call();
+      case 'move':
+        widget.onMove?.call();
+      case 'edit':
+        _startEditing();
+      case 'delete':
+        widget.onDelete();
+    }
   }
 
   @override

--- a/lib/widgets/pages/todo_page.dart
+++ b/lib/widgets/pages/todo_page.dart
@@ -161,10 +161,10 @@ class _TodoPageState extends State<TodoPage> {
   }
 
   Future<void> _showLists() async {
-    final selectedListId = await showDialog<TodoListId>(
+    final selectedListId = await showAdaptiveDialog<TodoListId>(
       context: context,
       builder: (dialogContext) {
-        return AlertDialog(
+        return AlertDialog.adaptive(
           title: const Text('Todo lists'),
           content: SizedBox(
             width: 320,
@@ -200,10 +200,10 @@ class _TodoPageState extends State<TodoPage> {
                             );
                             return;
                           }
-                          final confirmed = await showDialog<bool>(
+                          final confirmed = await showAdaptiveDialog<bool>(
                             context: dialogContext,
                             builder:
-                                (context) => AlertDialog(
+                                (context) => AlertDialog.adaptive(
                                   title: const Text('Delete list?'),
                                   content: Text(
                                     'Delete "${list.title}" and all of its tasks?',
@@ -318,7 +318,10 @@ class _TodoPageState extends State<TodoPage> {
   }
 
   void _showSettings() {
-    showDialog(context: context, builder: (context) => const SettingsDialog());
+    showAdaptiveDialog(
+      context: context,
+      builder: (context) => const SettingsDialog(),
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- use adaptive dialogs for settings, list selection, and list deletion confirmation
- show a Cupertino action sheet for TodoItem actions on iOS and macOS
- retain the existing Material popup menu on Android and Windows
- mark the delete action as destructive and provide a cancel action on Apple platforms

## Validation
- 
- 
- 

Closes #53