### PR TITLE
Restore the most recent todo list and remove title indexes

### DIFF
--- a/lib/constants/storage_keys.dart
+++ b/lib/constants/storage_keys.dart
@@ -3,6 +3,7 @@ import '../models/todo_list_id.dart';
 class StorageKeys {
   static const String todoListCatalog = 'todo_list_catalog';
   static const String openListIds = 'open_list_ids';
+  static const String lastActiveListId = 'last_active_list_id';
   static const String selectedTheme = 'selected_theme';
 
   /// Prefix used by releases before the todo-list persistence boundary.

--- a/lib/services/todo_list_catalog_service.dart
+++ b/lib/services/todo_list_catalog_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -40,6 +41,50 @@ class TodoListCatalogService {
     final lists = await loadLists();
     if (lists.isNotEmpty) return lists.first;
     return createList();
+  }
+
+  Future<TodoListId?> loadLastActiveListId() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    final value = prefs.getString(StorageKeys.lastActiveListId);
+    if (value == null || value.trim().isEmpty) return null;
+    return TodoListId.fromValue(value);
+  }
+
+  Future<void> markListActive(TodoListId listId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(StorageKeys.lastActiveListId, listId.value);
+  }
+
+  Future<bool> hasTodos(TodoListId listId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    final todosJson = prefs.getString(StorageKeys.todosForList(listId));
+    return todosJson != null && _decodeTodos(todosJson).isNotEmpty;
+  }
+
+  Future<TodoListRecord?> mostRecentNonEmptyList(
+    List<TodoListRecord> lists,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+
+    TodoListRecord? mostRecent;
+    var mostRecentScore = -1;
+    for (final list in lists) {
+      final todosJson = prefs.getString(StorageKeys.todosForList(list.id));
+      if (todosJson == null) continue;
+
+      final todos = _decodeTodos(todosJson);
+      if (todos.isEmpty) continue;
+
+      final score = _recencyScore(list.id, todos);
+      if (mostRecent == null || score > mostRecentScore) {
+        mostRecent = list;
+        mostRecentScore = score;
+      }
+    }
+    return mostRecent;
   }
 
   Future<TodoListRecord> createList({String title = defaultTitle}) async {
@@ -128,6 +173,32 @@ class TodoListCatalogService {
       if (original[index].title != normalized[index].title) return true;
     }
     return false;
+  }
+
+  List<Map<String, dynamic>> _decodeTodos(String encoded) {
+    try {
+      final decoded = jsonDecode(encoded) as List<dynamic>;
+      return [
+        for (final item in decoded)
+          if (item is Map<String, dynamic>) item,
+      ];
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  int _recencyScore(TodoListId listId, List<Map<String, dynamic>> todos) {
+    final listTimestamp = _lastNumericPart(listId.value);
+    final latestTodoTimestamp = todos.fold<int>(
+      0,
+      (latest, todo) => max(latest, int.tryParse('${todo['id']}') ?? 0),
+    );
+    return max(listTimestamp, latestTodoTimestamp);
+  }
+
+  int _lastNumericPart(String value) {
+    final match = RegExp(r'(\d+)$').firstMatch(value);
+    return int.tryParse(match?.group(1) ?? '') ?? 0;
   }
 
   Future<void> _saveLists(

--- a/lib/widgets/pages/todo_page.dart
+++ b/lib/widgets/pages/todo_page.dart
@@ -42,7 +42,16 @@ class _TodoPageState extends State<TodoPage> {
       for (final list in lists) {
         if (list.id == widget.initialListId) selectedList = list;
       }
-    } else if (WindowManager.supportsWindowManagement) {
+    } else {
+      final lastActiveListId = await _catalog.loadLastActiveListId();
+      if (lastActiveListId != null &&
+          lists.any((list) => list.id == lastActiveListId) &&
+          await _catalog.hasTodos(lastActiveListId)) {
+        selectedList = lists.firstWhere((list) => list.id == lastActiveListId);
+      }
+    }
+    selectedList ??= await _catalog.mostRecentNonEmptyList(lists);
+    if (selectedList == null && WindowManager.supportsWindowManagement) {
       final openListIds = await WindowRegistryService.getOpenListIds();
       for (final list in lists) {
         if (openListIds.contains(list.id.value)) {
@@ -55,6 +64,9 @@ class _TodoPageState extends State<TodoPage> {
     _windowTitle = selectedList.title;
 
     if (WindowManager.supportsWindowManagement) {
+      if (widget.windowController == null) {
+        await _catalog.markListActive(_listId!);
+      }
       await WindowRegistryService.registerOpenList(_listId!.value);
       if (widget.windowController != null) {
         await widget.windowController!.setFrameAutosaveName(
@@ -125,6 +137,7 @@ class _TodoPageState extends State<TodoPage> {
 
   Future<void> _createNewWindow() async {
     final newList = await _catalog.createList();
+    await _catalog.markListActive(newList.id);
     await WindowRegistryService.registerOpenList(newList.id.value);
     await WindowManager.createWindow(
       listId: newList.id.value,
@@ -149,6 +162,7 @@ class _TodoPageState extends State<TodoPage> {
     _todoService = nextService;
     _listId = listId;
     _windowTitle = selected.title;
+    await _catalog.markListActive(listId);
     await nextService.ready;
     previousService?.dispose();
     if (!mounted) return;

--- a/test/todo_list_catalog_service_test.dart
+++ b/test/todo_list_catalog_service_test.dart
@@ -86,6 +86,35 @@ void main() {
       },
     );
 
+    test('persists and reloads the last active list', () async {
+      final first = await catalog.createList(title: 'First');
+      final second = await catalog.createList(title: 'Second');
+
+      await catalog.markListActive(second.id);
+
+      expect(await catalog.loadLastActiveListId(), second.id);
+      expect(await catalog.hasTodos(first.id), isFalse);
+    });
+
+    test('finds the most recent non-empty list from persisted data', () async {
+      final older = await catalog.createList(title: 'Older');
+      final newer = await catalog.createList(title: 'Newer');
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        StorageKeys.todosForList(older.id),
+        '[{"id":"100","text":"Older task","isCompleted":false}]',
+      );
+      await prefs.setString(
+        StorageKeys.todosForList(newer.id),
+        '[{"id":"200","text":"Newer task","isCompleted":false}]',
+      );
+
+      final lists = await catalog.loadLists();
+      final mostRecent = await catalog.mostRecentNonEmptyList(lists);
+
+      expect(mostRecent?.id, newer.id);
+    });
+
     test('deletes a list, its tasks, and its open session entry', () async {
       final created = await catalog.createList();
       final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
## Summary
- persist the last active logical todo list
- restore the last active non-empty list on startup
- fall back to the most recent non-empty persisted list for legacy data
- normalize legacy numeric title suffixes without deleting stored data
- add regression tests for recency and title behavior

## Validation
- fvm flutter analyze
- fvm flutter test
- git diff --check

Closes #63