### PR TITLE
Restore task history from Settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,12 @@ BUNDLE_CMD ?= bundle
 IOS_BUNDLE_DIR ?= /tmp/tsubusu-bundle
 FASTLANE_CMD ?= $(BUNDLE_CMD) exec fastlane
 IOS_BUILD_ENV = $(if $(BUILD_NAME),BUILD_NAME='$(BUILD_NAME)') $(if $(BUILD_NUMBER),BUILD_NUMBER='$(BUILD_NUMBER)')
+MACOS_BUNDLE_ID ?= com.example.tsubusu
+MACOS_APP_NAME ?= tsubusu
+MACOS_APP_DEST ?= /Applications/$(MACOS_APP_NAME).app
 
 .PHONY: help clean-generated clean-generated-full clean-generated-dry-run flutter-clean \
-	ios-fastlane-install ios-ipa ios-beta ios-release
+	ios-fastlane-install ios-ipa ios-beta ios-release macos-install
 
 help:
 	@echo "Available targets:"
@@ -21,6 +24,7 @@ help:
 	@echo "  ios-ipa                   Build an iOS IPA with Flutter"
 	@echo "  ios-beta                  Build or reuse an IPA and upload it to TestFlight"
 	@echo "  ios-release               Upload IPA_PATH to App Store Connect without submitting"
+	@echo "  macos-install             Build, back up data, install, and launch the macOS app"
 
 clean-generated:
 	$(DART) run tool/clean_generated.dart --normal
@@ -46,3 +50,27 @@ ios-beta: ios-fastlane-install
 ios-release: ios-fastlane-install
 	@test -n "$(IPA_PATH)" || (echo "Usage: make ios-release IPA_PATH=/path/to/app.ipa" && exit 1)
 	cd ios && IPA_PATH='$(IPA_PATH)' BUNDLE_PATH=$(IOS_BUNDLE_DIR) $(FASTLANE_CMD) ios release
+
+macos-install:
+	@set -eu; \
+	if pgrep -x "$(MACOS_APP_NAME)" >/dev/null 2>&1; then \
+		echo "Please close $(MACOS_APP_NAME) before running make macos-install."; \
+		exit 1; \
+	fi; \
+	$(FLUTTER) build macos --release; \
+	timestamp=$$(date +%Y%m%d-%H%M%S); \
+	prefs="$$HOME/Library/Containers/$(MACOS_BUNDLE_ID)/Data/Library/Preferences/$(MACOS_BUNDLE_ID).plist"; \
+	if [ -f "$$prefs" ]; then \
+		cp "$$prefs" "$$HOME/Desktop/$(MACOS_APP_NAME)-preferences-backup-$$timestamp.plist"; \
+		echo "Preferences backed up to Desktop."; \
+	else \
+		echo "No existing preferences file found; continuing."; \
+	fi; \
+	if [ -d "$(MACOS_APP_DEST)" ]; then \
+		old_app="/Applications/$(MACOS_APP_NAME)-old.app"; \
+		rm -rf "$$old_app"; \
+		mv "$(MACOS_APP_DEST)" "$$old_app"; \
+		echo "Previous app moved to $$old_app."; \
+	fi; \
+	ditto "build/macos/Build/Products/Release/$(MACOS_APP_NAME).app" "$(MACOS_APP_DEST)"; \
+	open "$(MACOS_APP_DEST)"

--- a/lib/models/todo_list_history.dart
+++ b/lib/models/todo_list_history.dart
@@ -1,0 +1,32 @@
+import 'todo.dart';
+import 'todo_list_id.dart';
+
+class TodoListHistory {
+  final TodoListId id;
+  final String title;
+  final List<Todo> todos;
+  final bool isLegacy;
+  final int recencyScore;
+
+  const TodoListHistory({
+    required this.id,
+    required this.title,
+    required this.todos,
+    required this.isLegacy,
+    required this.recencyScore,
+  });
+
+  int get taskCount => todos.length;
+
+  String get formatLabel => isLegacy ? 'Legacy' : 'Current';
+
+  String get recencyLabel {
+    if (recencyScore < 1000000000000) return 'Older history';
+    final date = DateTime.fromMicrosecondsSinceEpoch(recencyScore).toLocal();
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    final hour = date.hour.toString().padLeft(2, '0');
+    final minute = date.minute.toString().padLeft(2, '0');
+    return '${date.year}-$month-$day $hour:$minute';
+  }
+}

--- a/lib/services/todo_list_catalog_service.dart
+++ b/lib/services/todo_list_catalog_service.dart
@@ -96,13 +96,16 @@ class TodoListCatalogService {
     await prefs.reload();
     final lists = await loadLists();
     final titles = {for (final list in lists) list.id.value: list.title};
+    final currentListIds = titles.keys.toSet();
     final encodedById = <String, String>{};
 
     for (final key in prefs.getKeys()) {
       if (key.startsWith('todos_list_')) {
         final id = key.substring('todos_list_'.length);
         final encoded = prefs.getString(key);
-        if (id.isNotEmpty && encoded != null) encodedById[id] = encoded;
+        if (id.isNotEmpty && !currentListIds.contains(id) && encoded != null) {
+          encodedById[id] = encoded;
+        }
       } else if (key.startsWith(StorageKeys.legacyWindowTodosPrefix)) {
         final suffix = key.substring(
           StorageKeys.legacyWindowTodosPrefix.length,

--- a/lib/services/todo_list_catalog_service.dart
+++ b/lib/services/todo_list_catalog_service.dart
@@ -4,7 +4,9 @@ import 'dart:math';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../constants/storage_keys.dart';
+import '../models/todo.dart';
 import '../models/todo_list_id.dart';
+import '../models/todo_list_history.dart';
 import '../models/todo_list_record.dart';
 
 class TodoListCatalogService {
@@ -85,6 +87,74 @@ class TodoListCatalogService {
       }
     }
     return mostRecent;
+  }
+
+  Future<List<TodoListHistory>> loadTaskHistory({
+    bool includeEmpty = false,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    final lists = await loadLists();
+    final titles = {for (final list in lists) list.id.value: list.title};
+    final encodedById = <String, String>{};
+
+    for (final key in prefs.getKeys()) {
+      if (key.startsWith('todos_list_')) {
+        final id = key.substring('todos_list_'.length);
+        final encoded = prefs.getString(key);
+        if (id.isNotEmpty && encoded != null) encodedById[id] = encoded;
+      } else if (key.startsWith(StorageKeys.legacyWindowTodosPrefix)) {
+        final suffix = key.substring(
+          StorageKeys.legacyWindowTodosPrefix.length,
+        );
+        final id = TodoListId.fromLegacyWindowId('window_$suffix').value;
+        final encoded = prefs.getString(key);
+        if (encoded != null && !encodedById.containsKey(id)) {
+          encodedById[id] = encoded;
+        }
+      }
+    }
+
+    final histories = <TodoListHistory>[];
+    for (final entry in encodedById.entries) {
+      final todos = _decodeTodoModels(entry.value);
+      if (!includeEmpty && todos.isEmpty) continue;
+      final id = TodoListId.fromValue(entry.key);
+      histories.add(
+        TodoListHistory(
+          id: id,
+          title: titles[entry.key] ?? defaultTitle,
+          todos: todos,
+          isLegacy: entry.key.startsWith('legacy_'),
+          recencyScore: _recencyScore(id, [
+            for (final todo in todos) todo.toJson(),
+          ]),
+        ),
+      );
+    }
+
+    histories.sort((a, b) {
+      final score = b.recencyScore.compareTo(a.recencyScore);
+      return score != 0 ? score : b.id.value.compareTo(a.id.value);
+    });
+    return histories;
+  }
+
+  Future<TodoListRecord> restoreHistory(TodoListHistory history) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    final lists = await _loadListsFromPreferences(prefs);
+    final restored = TodoListRecord(
+      id: TodoListId.create(),
+      title: '${history.title} (Recovered)',
+    );
+    lists.add(restored);
+    await _saveLists(prefs, lists);
+    await prefs.setString(
+      StorageKeys.todosForList(restored.id),
+      jsonEncode(history.todos.map((todo) => todo.toJson()).toList()),
+    );
+    return restored;
   }
 
   Future<TodoListRecord> createList({String title = defaultTitle}) async {
@@ -185,6 +255,19 @@ class TodoListCatalogService {
     } catch (_) {
       return const [];
     }
+  }
+
+  List<Todo> _decodeTodoModels(String encoded) {
+    final todos = <Todo>[];
+    for (final item in _decodeTodos(encoded)) {
+      try {
+        todos.add(Todo.fromJson(item));
+      } catch (_) {
+        // Ignore malformed records while keeping the rest of the history
+        // available for preview and recovery.
+      }
+    }
+    return todos;
   }
 
   int _recencyScore(TodoListId listId, List<Map<String, dynamic>> todos) {

--- a/lib/widgets/molecules/settings_dialog.dart
+++ b/lib/widgets/molecules/settings_dialog.dart
@@ -35,41 +35,46 @@ class _SettingsDialogState extends State<SettingsDialog> {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog.adaptive(
+    return AlertDialog(
       title: const CustomText('Settings'),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const CustomText(
-            'Task data:',
-            style: TextStyle(fontWeight: FontWeight.bold),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxHeight: 420, maxWidth: 420),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const CustomText(
+                'Task data:',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const CustomText('Task history'),
+                trailing: const Icon(Icons.history),
+                onTap: () {
+                  Navigator.pop(context);
+                  widget.onOpenTaskHistory?.call();
+                },
+              ),
+              const SizedBox(height: 8),
+              const CustomText(
+                'Theme:',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 8),
+              ...AppTheme.predefinedThemes.map(
+                (theme) => RadioListTile<ThemeType>(
+                  title: CustomText(theme.displayName),
+                  value: theme.type,
+                  groupValue: _selectedThemeType,
+                  onChanged: _handleThemeChange,
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 0),
+                ),
+              ),
+            ],
           ),
-          ListTile(
-            contentPadding: EdgeInsets.zero,
-            title: const CustomText('Task history'),
-            trailing: const Icon(Icons.history),
-            onTap: () {
-              Navigator.pop(context);
-              widget.onOpenTaskHistory?.call();
-            },
-          ),
-          const SizedBox(height: 8),
-          const CustomText(
-            'Theme:',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 8),
-          ...AppTheme.predefinedThemes.map(
-            (theme) => RadioListTile<ThemeType>(
-              title: CustomText(theme.displayName),
-              value: theme.type,
-              groupValue: _selectedThemeType,
-              onChanged: _handleThemeChange,
-              contentPadding: const EdgeInsets.symmetric(horizontal: 0),
-            ),
-          ),
-        ],
+        ),
       ),
       actions: [
         TextButton(

--- a/lib/widgets/molecules/settings_dialog.dart
+++ b/lib/widgets/molecules/settings_dialog.dart
@@ -5,9 +5,7 @@ import '../../providers/theme_provider.dart';
 import '../atoms/custom_text.dart';
 
 class SettingsDialog extends StatefulWidget {
-  final VoidCallback? onOpenTaskHistory;
-
-  const SettingsDialog({super.key, this.onOpenTaskHistory});
+  const SettingsDialog({super.key});
 
   @override
   State<SettingsDialog> createState() => _SettingsDialogState();
@@ -44,20 +42,6 @@ class _SettingsDialogState extends State<SettingsDialog> {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const CustomText(
-                'Task data:',
-                style: TextStyle(fontWeight: FontWeight.bold),
-              ),
-              ListTile(
-                contentPadding: EdgeInsets.zero,
-                title: const CustomText('Task history'),
-                trailing: const Icon(Icons.history),
-                onTap: () {
-                  Navigator.pop(context);
-                  widget.onOpenTaskHistory?.call();
-                },
-              ),
-              const SizedBox(height: 8),
               const CustomText(
                 'Theme:',
                 style: TextStyle(fontWeight: FontWeight.bold),

--- a/lib/widgets/molecules/settings_dialog.dart
+++ b/lib/widgets/molecules/settings_dialog.dart
@@ -37,41 +37,39 @@ class _SettingsDialogState extends State<SettingsDialog> {
   Widget build(BuildContext context) {
     return AlertDialog.adaptive(
       title: const CustomText('Settings'),
-      content: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const CustomText(
-              'Task data:',
-              style: TextStyle(fontWeight: FontWeight.bold),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const CustomText(
+            'Task data:',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            title: const CustomText('Task history'),
+            trailing: const Icon(Icons.history),
+            onTap: () {
+              Navigator.pop(context);
+              widget.onOpenTaskHistory?.call();
+            },
+          ),
+          const SizedBox(height: 8),
+          const CustomText(
+            'Theme:',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          ...AppTheme.predefinedThemes.map(
+            (theme) => RadioListTile<ThemeType>(
+              title: CustomText(theme.displayName),
+              value: theme.type,
+              groupValue: _selectedThemeType,
+              onChanged: _handleThemeChange,
+              contentPadding: const EdgeInsets.symmetric(horizontal: 0),
             ),
-            ListTile(
-              contentPadding: EdgeInsets.zero,
-              title: const CustomText('Task history'),
-              trailing: const Icon(Icons.history),
-              onTap: () {
-                Navigator.pop(context);
-                widget.onOpenTaskHistory?.call();
-              },
-            ),
-            const SizedBox(height: 8),
-            const CustomText(
-              'Theme:',
-              style: TextStyle(fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 8),
-            ...AppTheme.predefinedThemes.map(
-              (theme) => RadioListTile<ThemeType>(
-                title: CustomText(theme.displayName),
-                value: theme.type,
-                groupValue: _selectedThemeType,
-                onChanged: _handleThemeChange,
-                contentPadding: const EdgeInsets.symmetric(horizontal: 0),
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
       actions: [
         TextButton(

--- a/lib/widgets/molecules/settings_dialog.dart
+++ b/lib/widgets/molecules/settings_dialog.dart
@@ -5,7 +5,9 @@ import '../../providers/theme_provider.dart';
 import '../atoms/custom_text.dart';
 
 class SettingsDialog extends StatefulWidget {
-  const SettingsDialog({super.key});
+  final VoidCallback? onOpenTaskHistory;
+
+  const SettingsDialog({super.key, this.onOpenTaskHistory});
 
   @override
   State<SettingsDialog> createState() => _SettingsDialogState();
@@ -40,7 +42,20 @@ class _SettingsDialogState extends State<SettingsDialog> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Theme Selection Section
+            const CustomText(
+              'Task data:',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const CustomText('Task history'),
+              trailing: const Icon(Icons.history),
+              onTap: () {
+                Navigator.pop(context);
+                widget.onOpenTaskHistory?.call();
+              },
+            ),
+            const SizedBox(height: 8),
             const CustomText(
               'Theme:',
               style: TextStyle(fontWeight: FontWeight.bold),

--- a/lib/widgets/molecules/task_history_dialog.dart
+++ b/lib/widgets/molecules/task_history_dialog.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+
+import '../../models/todo.dart';
+import '../../models/todo_list_history.dart';
+import '../../models/todo_list_id.dart';
+import '../../services/todo_list_catalog_service.dart';
+
+class TaskHistoryDialog extends StatefulWidget {
+  final TodoListCatalogService catalog;
+
+  const TaskHistoryDialog({super.key, required this.catalog});
+
+  @override
+  State<TaskHistoryDialog> createState() => _TaskHistoryDialogState();
+}
+
+class _TaskHistoryDialogState extends State<TaskHistoryDialog> {
+  bool _includeEmpty = false;
+
+  Future<void> _previewHistory(TodoListHistory history) async {
+    final shouldRestore = await showAdaptiveDialog<bool>(
+      context: context,
+      builder: (context) => _TaskHistoryPreviewDialog(history: history),
+    );
+    if (shouldRestore != true || !mounted) return;
+
+    final restored = await widget.catalog.restoreHistory(history);
+    if (mounted) Navigator.pop<TodoListId>(context, restored.id);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog.adaptive(
+      title: const Text('Task history'),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420, maxHeight: 420),
+        child: SizedBox(
+          width: double.infinity,
+          height: 420,
+          child: FutureBuilder<List<TodoListHistory>>(
+            future: widget.catalog.loadTaskHistory(includeEmpty: _includeEmpty),
+            builder: (context, snapshot) {
+              if (!snapshot.hasData) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final histories = snapshot.data!;
+              if (histories.isEmpty) {
+                return const Center(child: Text('No task history found.'));
+              }
+              return ListView.separated(
+                itemCount: histories.length,
+                separatorBuilder: (_, _) => const Divider(height: 1),
+                itemBuilder: (context, index) {
+                  final history = histories[index];
+                  return ListTile(
+                    title: Text(history.recencyLabel),
+                    subtitle: Text(
+                      '${history.taskCount} tasks · ${history.formatLabel}',
+                    ),
+                    trailing: TextButton(
+                      onPressed: () => _previewHistory(history),
+                      child: const Text('View'),
+                    ),
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => setState(() => _includeEmpty = !_includeEmpty),
+          child: Text(
+            _includeEmpty ? 'Hide empty histories' : 'Show empty histories',
+          ),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+}
+
+class _TaskHistoryPreviewDialog extends StatelessWidget {
+  final TodoListHistory history;
+
+  const _TaskHistoryPreviewDialog({required this.history});
+
+  int _depthOf(Todo todo) {
+    var depth = 0;
+    var parentId = todo.parentId;
+    final visited = <String>{};
+    while (parentId != null && visited.add(parentId)) {
+      depth++;
+      final parent = history.todos.where((item) => item.id == parentId);
+      if (parent.isEmpty) break;
+      parentId = parent.first.parentId;
+    }
+    return depth;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog.adaptive(
+      title: Text('${history.recencyLabel} · ${history.taskCount} tasks'),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420, maxHeight: 360),
+        child: SizedBox(
+          width: double.infinity,
+          height: 360,
+          child: ListView.builder(
+            itemCount: history.todos.length,
+            itemBuilder: (context, index) {
+              final todo = history.todos[index];
+              return ListTile(
+                contentPadding: EdgeInsets.only(
+                  left: 16.0 + _depthOf(todo) * 20,
+                ),
+                leading: Icon(
+                  todo.isCompleted
+                      ? Icons.check_box
+                      : Icons.check_box_outline_blank,
+                ),
+                title: Text(todo.text),
+              );
+            },
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, true),
+          child: const Text('Restore as new list'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/molecules/task_history_dialog.dart
+++ b/lib/widgets/molecules/task_history_dialog.dart
@@ -30,7 +30,7 @@ class _TaskHistoryDialogState extends State<TaskHistoryDialog> {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog.adaptive(
+    return AlertDialog(
       title: const Text('Task history'),
       content: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 420, maxHeight: 420),
@@ -107,7 +107,7 @@ class _TaskHistoryPreviewDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog.adaptive(
+    return AlertDialog(
       title: Text('${history.recencyLabel} · ${history.taskCount} tasks'),
       content: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 420, maxHeight: 360),

--- a/lib/widgets/molecules/task_history_dialog.dart
+++ b/lib/widgets/molecules/task_history_dialog.dart
@@ -34,38 +34,41 @@ class _TaskHistoryDialogState extends State<TaskHistoryDialog> {
       title: const Text('Task history'),
       content: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 420, maxHeight: 420),
-        child: SizedBox(
-          width: double.infinity,
-          height: 420,
-          child: FutureBuilder<List<TodoListHistory>>(
-            future: widget.catalog.loadTaskHistory(includeEmpty: _includeEmpty),
-            builder: (context, snapshot) {
-              if (!snapshot.hasData) {
-                return const Center(child: CircularProgressIndicator());
-              }
-              final histories = snapshot.data!;
-              if (histories.isEmpty) {
-                return const Center(child: Text('No task history found.'));
-              }
-              return ListView.separated(
-                itemCount: histories.length,
-                separatorBuilder: (_, _) => const Divider(height: 1),
-                itemBuilder: (context, index) {
-                  final history = histories[index];
-                  return ListTile(
-                    title: Text(history.recencyLabel),
-                    subtitle: Text(
-                      '${history.taskCount} tasks · ${history.formatLabel}',
-                    ),
-                    trailing: TextButton(
-                      onPressed: () => _previewHistory(history),
-                      child: const Text('View'),
-                    ),
-                  );
-                },
+        child: FutureBuilder<List<TodoListHistory>>(
+          future: widget.catalog.loadTaskHistory(includeEmpty: _includeEmpty),
+          builder: (context, snapshot) {
+            if (!snapshot.hasData) {
+              return const Padding(
+                padding: EdgeInsets.all(24),
+                child: Center(child: CircularProgressIndicator()),
               );
-            },
-          ),
+            }
+            final histories = snapshot.data!;
+            if (histories.isEmpty) {
+              return const Padding(
+                padding: EdgeInsets.symmetric(vertical: 24),
+                child: Text('No task history found.'),
+              );
+            }
+            return ListView.separated(
+              shrinkWrap: true,
+              itemCount: histories.length,
+              separatorBuilder: (_, _) => const Divider(height: 1),
+              itemBuilder: (context, index) {
+                final history = histories[index];
+                return ListTile(
+                  title: Text(history.recencyLabel),
+                  subtitle: Text(
+                    '${history.taskCount} tasks · ${history.formatLabel}',
+                  ),
+                  trailing: TextButton(
+                    onPressed: () => _previewHistory(history),
+                    child: const Text('View'),
+                  ),
+                );
+              },
+            );
+          },
         ),
       ),
       actions: [
@@ -108,26 +111,21 @@ class _TaskHistoryPreviewDialog extends StatelessWidget {
       title: Text('${history.recencyLabel} · ${history.taskCount} tasks'),
       content: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 420, maxHeight: 360),
-        child: SizedBox(
-          width: double.infinity,
-          height: 360,
-          child: ListView.builder(
-            itemCount: history.todos.length,
-            itemBuilder: (context, index) {
-              final todo = history.todos[index];
-              return ListTile(
-                contentPadding: EdgeInsets.only(
-                  left: 16.0 + _depthOf(todo) * 20,
-                ),
-                leading: Icon(
-                  todo.isCompleted
-                      ? Icons.check_box
-                      : Icons.check_box_outline_blank,
-                ),
-                title: Text(todo.text),
-              );
-            },
-          ),
+        child: ListView.builder(
+          shrinkWrap: true,
+          itemCount: history.todos.length,
+          itemBuilder: (context, index) {
+            final todo = history.todos[index];
+            return ListTile(
+              contentPadding: EdgeInsets.only(left: 16.0 + _depthOf(todo) * 20),
+              leading: Icon(
+                todo.isCompleted
+                    ? Icons.check_box
+                    : Icons.check_box_outline_blank,
+              ),
+              title: Text(todo.text),
+            );
+          },
         ),
       ),
       actions: [

--- a/lib/widgets/pages/todo_page.dart
+++ b/lib/widgets/pages/todo_page.dart
@@ -179,7 +179,7 @@ class _TodoPageState extends State<TodoPage> {
     final selectedListId = await showAdaptiveDialog<TodoListId>(
       context: context,
       builder: (dialogContext) {
-        return AlertDialog.adaptive(
+        return AlertDialog(
           title: const Text('Todo lists'),
           content: SizedBox(
             width: 320,

--- a/lib/widgets/pages/todo_page.dart
+++ b/lib/widgets/pages/todo_page.dart
@@ -9,6 +9,7 @@ import '../../services/window_manager.dart';
 import '../organisms/app_header.dart';
 import '../organisms/todo_list.dart';
 import '../molecules/settings_dialog.dart';
+import '../molecules/task_history_dialog.dart';
 
 class TodoPage extends StatefulWidget {
   final WindowController? windowController;
@@ -334,8 +335,25 @@ class _TodoPageState extends State<TodoPage> {
   void _showSettings() {
     showAdaptiveDialog(
       context: context,
-      builder: (context) => const SettingsDialog(),
+      builder:
+          (context) => SettingsDialog(
+            onOpenTaskHistory: () {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (mounted) _showTaskHistory();
+              });
+            },
+          ),
     );
+  }
+
+  Future<void> _showTaskHistory() async {
+    final restoredListId = await showAdaptiveDialog<TodoListId>(
+      context: context,
+      builder: (context) => TaskHistoryDialog(catalog: _catalog),
+    );
+    if (restoredListId != null && mounted) {
+      await _switchList(restoredListId);
+    }
   }
 
   @override

--- a/lib/widgets/pages/todo_page.dart
+++ b/lib/widgets/pages/todo_page.dart
@@ -176,87 +176,90 @@ class _TodoPageState extends State<TodoPage> {
   }
 
   Future<void> _showLists() async {
+    final lists = await _catalog.loadLists();
+    final recoverableHistory = await _catalog.loadTaskHistory();
+    if (!mounted) return;
+    var shouldRecoverOldData = false;
     final selectedListId = await showAdaptiveDialog<TodoListId>(
       context: context,
       builder: (dialogContext) {
         return AlertDialog(
           title: const Text('Todo lists'),
-          content: SizedBox(
-            width: 320,
-            child: FutureBuilder<List<TodoListRecord>>(
-              future: _catalog.loadLists(),
-              builder: (context, snapshot) {
-                if (!snapshot.hasData) {
-                  return const SizedBox(
-                    height: 100,
-                    child: Center(child: CircularProgressIndicator()),
-                  );
-                }
-                final lists = snapshot.data!;
-                return ListView.builder(
-                  shrinkWrap: true,
-                  itemCount: lists.length,
-                  itemBuilder: (context, index) {
-                    final list = lists[index];
-                    return ListTile(
-                      selected: list.id == _listId,
-                      leading: const Icon(Icons.check_box_outlined),
-                      title: Text(list.title),
-                      onTap: () => Navigator.pop(dialogContext, list.id),
-                      trailing: IconButton(
-                        icon: const Icon(Icons.delete_outline),
-                        tooltip: 'Delete list',
-                        onPressed: () async {
-                          if (lists.length == 1) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                content: Text('At least one list must remain.'),
-                              ),
-                            );
-                            return;
-                          }
-                          final confirmed = await showAdaptiveDialog<bool>(
-                            context: dialogContext,
-                            builder:
-                                (context) => AlertDialog.adaptive(
-                                  title: const Text('Delete list?'),
-                                  content: Text(
-                                    'Delete "${list.title}" and all of its tasks?',
-                                  ),
-                                  actions: [
-                                    TextButton(
-                                      onPressed:
-                                          () => Navigator.pop(context, false),
-                                      child: const Text('Cancel'),
-                                    ),
-                                    FilledButton(
-                                      onPressed:
-                                          () => Navigator.pop(context, true),
-                                      child: const Text('Delete'),
-                                    ),
-                                  ],
-                                ),
+          content: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 420, maxHeight: 420),
+            child: SizedBox(
+              width: 320,
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: lists.length,
+                itemBuilder: (context, index) {
+                  final list = lists[index];
+                  return ListTile(
+                    selected: list.id == _listId,
+                    leading: const Icon(Icons.check_box_outlined),
+                    title: Text(list.title),
+                    onTap: () => Navigator.pop(dialogContext, list.id),
+                    trailing: IconButton(
+                      icon: const Icon(Icons.delete_outline),
+                      tooltip: 'Delete list',
+                      onPressed: () async {
+                        if (lists.length == 1) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('At least one list must remain.'),
+                            ),
                           );
-                          if (confirmed != true) return;
-                          await _catalog.deleteList(list.id);
-                          if (!dialogContext.mounted) return;
-                          if (list.id == _listId) {
-                            final fallback = lists.firstWhere(
-                              (candidate) => candidate.id != list.id,
-                            );
-                            Navigator.pop(dialogContext, fallback.id);
-                          } else {
-                            Navigator.pop(dialogContext);
-                          }
-                        },
-                      ),
-                    );
-                  },
-                );
-              },
+                          return;
+                        }
+                        final confirmed = await showAdaptiveDialog<bool>(
+                          context: dialogContext,
+                          builder:
+                              (context) => AlertDialog.adaptive(
+                                title: const Text('Delete list?'),
+                                content: Text(
+                                  'Delete "${list.title}" and all of its tasks?',
+                                ),
+                                actions: [
+                                  TextButton(
+                                    onPressed:
+                                        () => Navigator.pop(context, false),
+                                    child: const Text('Cancel'),
+                                  ),
+                                  FilledButton(
+                                    onPressed:
+                                        () => Navigator.pop(context, true),
+                                    child: const Text('Delete'),
+                                  ),
+                                ],
+                              ),
+                        );
+                        if (confirmed != true) return;
+                        await _catalog.deleteList(list.id);
+                        if (!dialogContext.mounted) return;
+                        if (list.id == _listId) {
+                          final fallback = lists.firstWhere(
+                            (candidate) => candidate.id != list.id,
+                          );
+                          Navigator.pop(dialogContext, fallback.id);
+                        } else {
+                          Navigator.pop(dialogContext);
+                        }
+                      },
+                    ),
+                  );
+                },
+              ),
             ),
           ),
           actions: [
+            if (recoverableHistory.isNotEmpty)
+              TextButton(
+                onPressed: () {
+                  shouldRecoverOldData = true;
+                  Navigator.pop(dialogContext);
+                },
+                child: const Text('Recover old data'),
+              ),
             TextButton(
               onPressed: () async {
                 final newList = await _catalog.createList();
@@ -276,6 +279,8 @@ class _TodoPageState extends State<TodoPage> {
     );
     if (selectedListId != null && mounted) {
       await _switchList(selectedListId);
+    } else if (shouldRecoverOldData && mounted) {
+      await _showTaskHistory();
     }
   }
 
@@ -335,14 +340,7 @@ class _TodoPageState extends State<TodoPage> {
   void _showSettings() {
     showAdaptiveDialog(
       context: context,
-      builder:
-          (context) => SettingsDialog(
-            onOpenTaskHistory: () {
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                if (mounted) _showTaskHistory();
-              });
-            },
-          ),
+      builder: (context) => const SettingsDialog(),
     );
   }
 

--- a/test/todo_list_catalog_service_test.dart
+++ b/test/todo_list_catalog_service_test.dart
@@ -115,10 +115,17 @@ void main() {
       expect(mostRecent?.id, newer.id);
     });
 
-    test('discovers current and legacy task histories newest first', () async {
+    test('discovers orphaned and legacy task histories newest first', () async {
+      final current = TodoListRecord(
+        id: TodoListId.fromValue('list_current'),
+        title: 'Current list',
+      );
       SharedPreferences.setMockInitialValues({
+        StorageKeys.todoListCatalog: jsonEncode([current.toJson()]),
+        'todos_list_list_current':
+            '[{"id":"400","text":"Current","isCompleted":false}]',
         'todos_list_list_200':
-            '[{"id":"200","text":"Current","isCompleted":false}]',
+            '[{"id":"200","text":"Orphaned","isCompleted":false}]',
         'todos_window_window_1':
             '[{"id":"100","text":"Legacy","isCompleted":false}]',
         'todos_list_list_300': '[]',
@@ -138,9 +145,11 @@ void main() {
       'restores a history as a new list without changing the source',
       () async {
         SharedPreferences.setMockInitialValues({
+          StorageKeys.todoListCatalog: '[]',
           'todos_list_list_200':
               '[{"id":"200","text":"Keep this","isCompleted":true}]',
         });
+        await catalog.ensureDefaultList();
         final history = (await catalog.loadTaskHistory()).single;
         final prefs = await SharedPreferences.getInstance();
 

--- a/test/todo_list_catalog_service_test.dart
+++ b/test/todo_list_catalog_service_test.dart
@@ -115,6 +115,47 @@ void main() {
       expect(mostRecent?.id, newer.id);
     });
 
+    test('discovers current and legacy task histories newest first', () async {
+      SharedPreferences.setMockInitialValues({
+        'todos_list_list_200':
+            '[{"id":"200","text":"Current","isCompleted":false}]',
+        'todos_window_window_1':
+            '[{"id":"100","text":"Legacy","isCompleted":false}]',
+        'todos_list_list_300': '[]',
+      });
+
+      final histories = await catalog.loadTaskHistory();
+      final allHistories = await catalog.loadTaskHistory(includeEmpty: true);
+
+      expect(histories, hasLength(2));
+      expect(histories.first.id, TodoListId.fromValue('list_200'));
+      expect(histories.first.isLegacy, isFalse);
+      expect(histories.last.isLegacy, isTrue);
+      expect(allHistories, hasLength(3));
+    });
+
+    test(
+      'restores a history as a new list without changing the source',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'todos_list_list_200':
+              '[{"id":"200","text":"Keep this","isCompleted":true}]',
+        });
+        final history = (await catalog.loadTaskHistory()).single;
+        final prefs = await SharedPreferences.getInstance();
+
+        final restored = await catalog.restoreHistory(history);
+
+        expect(restored.id, isNot(history.id));
+        expect(prefs.getString('todos_list_list_200'), contains('Keep this'));
+        expect(
+          prefs.getString(StorageKeys.todosForList(restored.id)),
+          contains('Keep this'),
+        );
+        expect(restored.title, 'tsubusu (Recovered)');
+      },
+    );
+
     test('deletes a list, its tasks, and its open session entry', () async {
       final created = await catalog.createList();
       final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
## Summary
- add Task history to Settings
- discover current and legacy persisted task lists in recency order
- provide read-only task previews with hierarchy and completion state
- restore history as a new logical list without overwriting the current list or source data
- support showing empty histories on demand
- add regression tests for discovery, ordering, and non-destructive restoration

## Validation
- fvm flutter analyze
- fvm flutter test
- git diff --check

Closes #65