### PR TITLE
Improve drag-and-drop task hierarchy

### DIFF
--- a/lib/widgets/molecules/todo_item.dart
+++ b/lib/widgets/molecules/todo_item.dart
@@ -22,7 +22,6 @@ class TodoItem extends StatefulWidget {
   final int? reorderIndex;
   final bool isCompleted;
   final bool isSubtask;
-  final bool canStartNesting;
 
   const TodoItem({
     super.key,
@@ -38,7 +37,6 @@ class TodoItem extends StatefulWidget {
     this.reorderIndex,
     this.isCompleted = false,
     this.isSubtask = false,
-    this.canStartNesting = false,
   });
 
   @override
@@ -250,7 +248,14 @@ class _TodoItemState extends State<TodoItem> {
                   onPressed: () => _showActions(context),
                   tooltip: 'その他の操作',
                 ),
-              if (widget.canStartNesting)
+              IconButtonAtom(
+                icon: Icons.delete_outline,
+                onPressed: widget.onDelete,
+                iconColor: themeProvider.completedTextColor,
+                size: DesignConstants.iconSizeStandard,
+              ),
+              if (!widget.todo.isCompleted && widget.reorderIndex != null) ...[
+                SizedBox(width: DesignConstants.spacingSmall),
                 LongPressDraggable<String>(
                   data: widget.todo.id,
                   feedback: Material(
@@ -262,33 +267,14 @@ class _TodoItemState extends State<TodoItem> {
                       constraints: const BoxConstraints(maxWidth: 280),
                       child: ListTile(
                         dense: true,
-                        leading: const Icon(Icons.subdirectory_arrow_right),
+                        leading: const Icon(Icons.drag_handle),
                         title: Text(widget.todo.text),
                       ),
                     ),
                   ),
-                  child: const Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 4),
-                    child: Tooltip(
-                      message: 'ドラッグしてサブタスク化',
-                      child: Icon(Icons.subdirectory_arrow_right),
-                    ),
-                  ),
-                ),
-              IconButtonAtom(
-                icon: Icons.delete_outline,
-                onPressed: widget.onDelete,
-                iconColor: themeProvider.completedTextColor,
-                size: DesignConstants.iconSizeStandard,
-              ),
-              if (!widget.todo.isCompleted && widget.reorderIndex != null) ...[
-                SizedBox(width: DesignConstants.spacingSmall),
-                ReorderableDragStartListener(
-                  index: widget.reorderIndex!,
-                  child: Icon(
-                    Icons.drag_handle,
-                    color: themeProvider.completedTextColor,
-                    size: DesignConstants.iconSizeStandard,
+                  child: const Tooltip(
+                    message: 'Drag to reorder or make a subtask',
+                    child: Icon(Icons.drag_handle),
                   ),
                 ),
               ],

--- a/lib/widgets/molecules/todo_item.dart
+++ b/lib/widgets/molecules/todo_item.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 import '../../constants/design_constants.dart';
@@ -46,14 +47,35 @@ class TodoItem extends StatefulWidget {
 class _TodoItemState extends State<TodoItem> {
   final _editController = TextEditingController();
   final _editFocusNode = FocusNode();
+  final _dragFocusNode = FocusNode();
   bool _isHovered = false;
   bool _isEditing = false;
+  int _dragVersion = 0;
 
   @override
   void dispose() {
     _editController.dispose();
     _editFocusNode.dispose();
+    _dragFocusNode.dispose();
     super.dispose();
+  }
+
+  KeyEventResult _handleDragKey(FocusNode node, KeyEvent event) {
+    if (event is KeyDownEvent &&
+        event.logicalKey == LogicalKeyboardKey.escape) {
+      setState(() => _dragVersion++);
+      node.unfocus();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  Offset _dragHandleAnchor(
+    Draggable<Object> draggable,
+    BuildContext context,
+    Offset position,
+  ) {
+    return const Offset(248, 24);
   }
 
   void _startEditing() {
@@ -256,25 +278,33 @@ class _TodoItemState extends State<TodoItem> {
               ),
               if (!widget.todo.isCompleted && widget.reorderIndex != null) ...[
                 SizedBox(width: DesignConstants.spacingSmall),
-                LongPressDraggable<String>(
-                  data: widget.todo.id,
-                  feedback: Material(
-                    elevation: 4,
-                    borderRadius: BorderRadius.circular(
-                      DesignConstants.borderRadiusStandard,
-                    ),
-                    child: ConstrainedBox(
-                      constraints: const BoxConstraints(maxWidth: 280),
-                      child: ListTile(
-                        dense: true,
-                        leading: const Icon(Icons.drag_handle),
-                        title: Text(widget.todo.text),
+                Focus(
+                  focusNode: _dragFocusNode,
+                  onKeyEvent: _handleDragKey,
+                  child: LongPressDraggable<String>(
+                    key: ValueKey('${widget.todo.id}-drag-$_dragVersion'),
+                    data: widget.todo.id,
+                    dragAnchorStrategy: _dragHandleAnchor,
+                    onDragStarted: _dragFocusNode.requestFocus,
+                    onDragEnd: (_) => _dragFocusNode.unfocus(),
+                    feedback: Material(
+                      elevation: 4,
+                      borderRadius: BorderRadius.circular(
+                        DesignConstants.borderRadiusStandard,
+                      ),
+                      child: SizedBox(
+                        width: 280,
+                        child: ListTile(
+                          dense: true,
+                          leading: const Icon(Icons.drag_handle),
+                          title: Text(widget.todo.text),
+                        ),
                       ),
                     ),
-                  ),
-                  child: const Tooltip(
-                    message: 'Drag to reorder or make a subtask',
-                    child: Icon(Icons.drag_handle),
+                    child: const Tooltip(
+                      message: 'Drag to reorder or make a subtask',
+                      child: Icon(Icons.drag_handle),
+                    ),
                   ),
                 ),
               ],

--- a/lib/widgets/organisms/todo_list.dart
+++ b/lib/widgets/organisms/todo_list.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -34,6 +36,8 @@ class TodoList extends StatefulWidget {
 
 class _TodoListState extends State<TodoList> {
   final _collapsedIds = <String>{};
+  Timer? _pendingExpansionTimer;
+  String? _pendingExpansionId;
   String? _addingForId;
   double _completedSectionHeight = 200.0;
   final double _minCompletedHeight = 80.0;
@@ -46,6 +50,32 @@ class _TodoListState extends State<TodoList> {
     setState(() {
       if (!_collapsedIds.add(id)) _collapsedIds.remove(id);
     });
+  }
+
+  void _scheduleExpansion(Todo target) {
+    if (_childrenOf(target.id).isNotEmpty &&
+        _collapsedIds.contains(target.id)) {
+      if (_pendingExpansionId == target.id) return;
+      _pendingExpansionTimer?.cancel();
+      _pendingExpansionId = target.id;
+      _pendingExpansionTimer = Timer(const Duration(milliseconds: 500), () {
+        if (!mounted || _pendingExpansionId != target.id) return;
+        setState(() => _collapsedIds.remove(target.id));
+        _pendingExpansionId = null;
+      });
+    }
+  }
+
+  void _cancelExpansion() {
+    _pendingExpansionTimer?.cancel();
+    _pendingExpansionTimer = null;
+    _pendingExpansionId = null;
+  }
+
+  @override
+  void dispose() {
+    _cancelExpansion();
+    super.dispose();
   }
 
   bool _canNest(String sourceId, String targetId) {
@@ -119,8 +149,14 @@ class _TodoListState extends State<TodoList> {
   }) {
     return DragTarget<String>(
       key: key,
-      onWillAcceptWithDetails: (details) => _canNest(details.data, target.id),
+      onWillAcceptWithDetails: (details) {
+        final canNest = _canNest(details.data, target.id);
+        if (canNest) _scheduleExpansion(target);
+        return canNest;
+      },
+      onLeave: (_) => _cancelExpansion(),
       onAcceptWithDetails: (details) async {
+        _cancelExpansion();
         final sources = widget.todos.where((todo) => todo.id == details.data);
         if (sources.isEmpty) return;
         await _nestInto(sources.first, target);
@@ -140,6 +176,66 @@ class _TodoListState extends State<TodoList> {
             ),
           ),
           child: child,
+        );
+      },
+    );
+  }
+
+  bool _canReorderAt(String? parentId, String sourceId) {
+    final source =
+        widget.todos.where((todo) => todo.id == sourceId).firstOrNull;
+    return source != null && source.parentId == parentId;
+  }
+
+  Future<void> _reorderAt(
+    String? parentId,
+    int dropIndex,
+    String sourceId,
+  ) async {
+    final siblings =
+        widget.todos.where((todo) => todo.parentId == parentId).toList();
+    final oldIndex = siblings.indexWhere((todo) => todo.id == sourceId);
+    if (oldIndex == -1 || oldIndex == dropIndex) return;
+
+    final newIndex =
+        dropIndex == siblings.length
+            ? dropIndex
+            : oldIndex < dropIndex
+            ? dropIndex + 1
+            : dropIndex;
+    widget.onReorderSiblings?.call(parentId, oldIndex, newIndex);
+  }
+
+  Widget _reorderDropZone(String? parentId, int dropIndex) {
+    return DragTarget<String>(
+      key: ValueKey('drop-zone-$parentId-$dropIndex'),
+      onWillAcceptWithDetails:
+          (details) => _canReorderAt(parentId, details.data),
+      onAcceptWithDetails:
+          (details) => _reorderAt(parentId, dropIndex, details.data),
+      builder: (context, candidateData, rejectedData) {
+        final isDropTarget = candidateData.isNotEmpty;
+        final themeProvider = Provider.of<ThemeProvider>(context);
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          height: isDropTarget ? 24 : 8,
+          margin: const EdgeInsets.symmetric(horizontal: 8),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(4),
+            color:
+                isDropTarget
+                    ? themeProvider.primaryColor.withValues(alpha: 0.35)
+                    : Colors.transparent,
+          ),
+          child:
+              isDropTarget
+                  ? Center(
+                    child: Container(
+                      height: 2,
+                      color: themeProvider.primaryColor,
+                    ),
+                  )
+                  : null,
         );
       },
     );
@@ -177,19 +273,18 @@ class _TodoListState extends State<TodoList> {
                   ),
                 ),
                 Expanded(
-                  child: ReorderableListView.builder(
+                  child: ListView.builder(
                     padding: const EdgeInsets.all(8),
-                    buildDefaultDragHandles: false,
-                    itemCount: openRoots.length,
-                    onReorder:
-                        (oldIndex, newIndex) => widget.onReorderSiblings?.call(
-                          null,
-                          oldIndex,
-                          newIndex,
-                        ),
+                    itemCount: openRoots.length * 2 + 1,
                     itemBuilder:
                         (context, index) =>
-                            _buildGroup(context, openRoots[index], index),
+                            index.isEven
+                                ? _reorderDropZone(null, index ~/ 2)
+                                : _buildGroup(
+                                  context,
+                                  openRoots[index ~/ 2],
+                                  index ~/ 2,
+                                ),
                   ),
                 ),
               ],
@@ -302,46 +397,43 @@ class _TodoListState extends State<TodoList> {
               onToggleExpanded: () => _toggleExpanded(parent.id),
               reorderIndex: completed ? null : rootReorderIndex,
               isCompleted: completed,
-              canStartNesting: !completed,
             ),
           ),
           if (children.isNotEmpty && isExpanded)
-            ReorderableListView.builder(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              buildDefaultDragHandles: false,
-              itemCount: children.length,
-              onReorder:
-                  (oldIndex, newIndex) => widget.onReorderSiblings?.call(
-                    parent.id,
-                    oldIndex,
-                    newIndex,
-                  ),
-              itemBuilder: (context, index) {
-                final child = children[index];
-                return Padding(
-                  key: ValueKey(child.id),
-                  padding: const EdgeInsets.only(left: 24, right: 24),
-                  child: _nestTarget(
-                    context,
-                    child,
-                    TodoItem(
-                      todo: child,
-                      isSubtask: true,
-                      onToggle: () => widget.onToggleTodo(child.id),
-                      onDelete: () => widget.onDeleteTodo(child.id),
-                      onMove:
-                          !completed
-                              ? () => _chooseNestTarget(context, child)
-                              : null,
-                      onEdit: (text) => widget.onEditTodo(child.id, text),
-                      reorderIndex: completed ? null : index,
-                      isCompleted: completed,
-                      canStartNesting: !completed,
+            Column(
+              children: [
+                for (var index = 0; index <= children.length; index++) ...[
+                  _reorderDropZone(parent.id, index),
+                  if (index < children.length)
+                    Padding(
+                      padding: const EdgeInsets.only(left: 24, right: 24),
+                      child: _nestTarget(
+                        context,
+                        children[index],
+                        TodoItem(
+                          todo: children[index],
+                          isSubtask: true,
+                          onToggle:
+                              () => widget.onToggleTodo(children[index].id),
+                          onDelete:
+                              () => widget.onDeleteTodo(children[index].id),
+                          onMove:
+                              !completed
+                                  ? () => _chooseNestTarget(
+                                    context,
+                                    children[index],
+                                  )
+                                  : null,
+                          onEdit:
+                              (text) =>
+                                  widget.onEditTodo(children[index].id, text),
+                          reorderIndex: completed ? null : index,
+                          isCompleted: completed,
+                        ),
+                      ),
                     ),
-                  ),
-                );
-              },
+                ],
+              ],
             ),
           if (_addingForId == parent.id)
             Padding(


### PR DESCRIPTION
## Summary

Closes #67

Improve drag-and-drop interactions so the right-side drag handle supports both sibling reordering and subtask creation.

## Changes

- Use the right-side drag handle as the task drag source.
- Add visible drop zones between tasks for same-level reordering.
- Drop on a task card to nest the dragged task as a subtask.
- Expand a collapsed parent after a short hover delay.
- Reject self and descendant nesting targets.
- Preserve the existing explicit move action and nesting undo behavior.

## Validation

- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`
